### PR TITLE
Update Docs: Release EIPs on cleanup

### DIFF
--- a/docs/instance-cleanup.md
+++ b/docs/instance-cleanup.md
@@ -52,6 +52,8 @@ You might end up in a situation where the broker is failing to cleanup resources
       - Delete the Key Signing Key (KSK) via Advanced view > Delete Key
       - Delete all records except for the NS and SOA records
       - Delete the zone
+1. [VPC > Elastic IPs](https://console.aws.amazon.com/vpc/home?region=us-west-2#Addresses:)
+    - Look for one tagged with the name of the k8s cluster and release it if present
 
 ## Out-of-region steps
 


### PR DESCRIPTION
Sometimes if a broken instance of EKS remains in AWS, it leaves a dangling Elastic IP Address tied to a specific domain.  If not cleaned up, these will hog resources and prevent new EIPs for new domains.

This is the documentation to clean it up.