### PR TITLE
Downgrade the solr-operator

### DIFF
--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -34,7 +34,7 @@ resource "helm_release" "solr-operator" {
   name            = "solr"
   chart           = "solr-operator"
   repository      = "https://solr.apache.org/charts"
-  version         = "0.4.0"
+  version         = "0.3.0"
   namespace       = "kube-system"
 
   set {

--- a/terraform/provision/logging.tf
+++ b/terraform/provision/logging.tf
@@ -53,7 +53,7 @@ data "template_file" "logging" {
           region ${local.region}
           log_group_name fluent-bit-cloudwatch-${local.cluster_name}
           log_stream_prefix from-fluent-bit-
-          auto_create_group On
+          auto_create_group true
   EOF
 }
 


### PR DESCRIPTION
This is to enable use of datagov-brokerpak-solr 0.20.0 so that we can have auth-enabled Solr clusters.