### PR TITLE
Downgrade all the way to solr-operator 0.2.8

### DIFF
--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -34,7 +34,7 @@ resource "helm_release" "solr-operator" {
   name            = "solr"
   chart           = "solr-operator"
   repository      = "https://solr.apache.org/charts"
-  version         = "0.3.0"
+  version         = "0.2.8"
   namespace       = "kube-system"
 
   set {


### PR DESCRIPTION
This is the version that the currently-supported solr-brokerpak needs.