### PR TITLE
Allow namespace admins to also list namespaces

### DIFF
--- a/terraform/bind/main.tf
+++ b/terraform/bind/main.tf
@@ -31,3 +31,23 @@ resource "kubernetes_role_binding" "binding" {
     namespace = local.namespace
   }
 }
+
+# Also make sure the service account can get (but not modify) namespaces
+resource "kubernetes_cluster_role_binding" "cluster_binding" {
+  metadata {
+    name      = "${kubernetes_service_account.account.metadata[0].name}-admin-role-cluster-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "namespace-reader"
+  }
+
+  subject {
+    api_group = ""
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.account.metadata[0].name
+    namespace = local.namespace
+  }
+}

--- a/terraform/provision/rbac.tf
+++ b/terraform/provision/rbac.tf
@@ -17,3 +17,22 @@ resource "kubernetes_role" "namespace_admin" {
     null_resource.cluster-functional,
   ]
 }
+
+# Admin roles may additionally need to list namespaces.
+# For example, if using the kubernetes_namespace data source in Terraform)
+resource "kubernetes_cluster_role" "namespace_reader" {
+  metadata {
+    name = "namespace-reader"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces"]
+    verbs      = ["list", "get"]
+  }
+
+  depends_on = [
+    null_resource.cluster-functional,
+  ]
+}
+


### PR DESCRIPTION
I'm changing the Solr broker so that namespace listing isn't required for it to do its thing, but it's a relatively harmless permission to grant to bindings that make help with debugging once we support multiple namespaces.