### PR TITLE
Avoid overlong LB names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: |
         INSTANCE_NAME="$(echo ci-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID})"
+        if [[ "$(echo -n ${INSTANCE_NAME} | wc -c)" -lt  "64" ]]; then
+          INSTANCE_NAME=${INSTANCE_NAME}-special-extra-long-padding-for-real-test-case-because-ssb-needs-it
+        fi
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
     - name: Run examples (tests)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         INSTANCE_NAME="$(echo ci-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID})"
         if [[ "$(echo -n ${INSTANCE_NAME} | wc -c)" -lt  "64" ]]; then
           INSTANCE_NAME=${INSTANCE_NAME}-special-extra-long-padding-for-real-test-case-because-ssb-needs-it
+          INSTANCE_NAME=$(head -c 64 <<< $test)
         fi
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         INSTANCE_NAME="$(echo ci-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID})"
         if [[ "$(echo -n ${INSTANCE_NAME} | wc -c)" -lt  "64" ]]; then
           INSTANCE_NAME=${INSTANCE_NAME}-special-extra-long-padding-for-real-test-case-because-ssb-needs-it
-          INSTANCE_NAME=$(head -c 64 <<< $test)
+          INSTANCE_NAME=$(head -c 64 <<< $INSTANCE_NAME)
         fi
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := help
 
 DOCKER_OPTS=--rm -v $(PWD):/brokerpak -w /brokerpak
-CSB=ghcr.io/gsa/cloud-service-broker:v0.5.1gsa
+CSB=ghcr.io/gsa/cloud-service-broker:v0.4.1gsa
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := help
 
 DOCKER_OPTS=--rm -v $(PWD):/brokerpak -w /brokerpak
-CSB=ghcr.io/gsa/cloud-service-broker:v0.4.1gsa
+CSB=ghcr.io/gsa/cloud-service-broker:v0.5.1gsa
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -29,7 +29,7 @@ provision:
       minLength: 2
       pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
     default: ${str.truncate(64, "${request.instance_id}")}
-    details: A subdomain to use for the cluster instance. Default is the instance ID.
+    details: A subdomain to use for the cluster instance. Default is the instance ID. Make sure the name meets AWS requirements (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
   - field_name: write_kubeconfig
     type: boolean
     details: "Specify whether the cluster kubeconfig is made available as an output"

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -115,7 +115,13 @@ data "template_file" "kubeconfig" {
     users:
     - name: terraform
       user:
-        token: ${data.aws_eks_cluster_auth.main.token}
+        exec:
+          apiVersion: client.authentication.k8s.io/v1alpha1
+          command: aws-iam-authenticator
+          args:
+            - "token"
+            - "-i"
+            - "${data.aws_eks_cluster.main.name}"
   EOF
 }
 

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -25,7 +25,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
-  version    = "3.37.0"
+  version    = "4.0.17"
 
   namespace       = "kube-system"
   cleanup_on_fail = "true"

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -1,7 +1,7 @@
 locals {
   base_domain = var.zone
   domain      = "${local.subdomain}.${local.base_domain}"
-  subdomain   = var.subdomain
+  subdomain   = length(var.subdomain) >= 64 ? trimsuffix(substr(var.subdomain, 0, 62), "-") : var.subdomain
 }
 
 # Use a convenient module to install the AWS Load Balancer controller

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -42,7 +42,7 @@ resource "helm_release" "ingress_nginx" {
       "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-proxy-protocol"   = "*",
       "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-backend-protocol" = "ssl"
 
-      "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-name" = local.subdomain,
+      "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-name" = substr(local.subdomain, 0, 32), # NLB names must be <=32 characters
       # "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-alpn-policy"    = "HTTP2Preferred",
       "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-negotiation-policy" = "ELBSecurityPolicy-TLS-1-2-2017-01"
       # Enable this to restrict clients by CIDR range

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -90,6 +90,7 @@ resource "helm_release" "ingress_nginx" {
   depends_on = [
     null_resource.cluster-functional,
     module.aws_load_balancer_controller,
+    time_sleep.alb_controller_destroy_delay
   ]
 }
 

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -1,7 +1,15 @@
 locals {
   base_domain = var.zone
-  domain      = "${local.subdomain}.${local.base_domain}"
-  subdomain   = length(var.subdomain) >= 64 ? trimsuffix(substr(var.subdomain, 0, 62), "-") : var.subdomain
+  domain = (
+    length("${local.subdomain}.${local.base_domain}") >= 64 ?
+    "${substr(local.subdomain, 0, 63 - length(local.base_domain))}.${local.base_domain}" :
+    "${local.subdomain}.${local.base_domain}"
+  )
+  subdomain = (
+    length(var.subdomain) >= 64 ?
+    trimsuffix(substr(var.subdomain, 0, 62), "-") :
+    var.subdomain
+  )
 }
 
 # Use a convenient module to install the AWS Load Balancer controller


### PR DESCRIPTION
This PR fixes [the problem where instances provisioned via the SSB time out while waiting for the ingress-nginx service to get an external IP](https://gsa-tts.slack.com/archives/C2N85536E/p1644996338677069?thread_ts=1644971323.182399&cid=C2N85536E).

As I mentioned in Slack:
> ...we've been bitten by this kind of thing before. I think we should alter our tests to use a 64-character instance ID so we'll find these problems before accepting PRs, rather than only after a long deployment process to get it in use by the SSB.

Feel free to make that change yourself before accepting this PR, or wait for me to do it tomorrow... Otherwise we can do it in another PR. I just need to get to bed now and wanted to get this in flight for the east-coast morning crew!