### PR TITLE
Add dependency for sc on cluster-functional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ jobs:
         shell: bash
 
     steps:  
-    - name: Install the eden OSBAPI CLI tool
-      run: |
-        wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | sudo apt-key add -
-        echo "deb http://apt.starkandwayne.com stable main" | sudo tee /etc/apt/sources.list.d/starkandwayne.list
-        sudo apt-get update
-        sudo apt-get install eden
     - name: Check out repository
       uses: actions/checkout@v2
       with: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,6 @@ jobs:
 
     # Checkout the repository to the GitHub Actions runner
     steps:
-    - name: Install the eden OSBAPI CLI tool
-      run: |
-        wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | sudo apt-key add -
-        echo "deb http://apt.starkandwayne.com stable main" | sudo tee /etc/apt/sources.list.d/starkandwayne.list
-        sudo apt-get update
-        sudo apt-get install eden
     - uses: actions/checkout@v2
       with: 
         fetch-depth: '0'

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ terraform/*/.terraform.lock.hcl
 kubeconfig_*
 kubeconfig-*
 *.swp
+terraform.log

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ kubeconfig_*
 kubeconfig-*
 *.swp
 terraform.log
+*.binding.json

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ up: ## Run the broker service with the brokerpak configured. The broker listens 
 	-e SECURITY_USER_NAME=$(SECURITY_USER_NAME) \
 	-e SECURITY_USER_PASSWORD=$(SECURITY_USER_PASSWORD) \
 	-e GSB_DEBUG=true \
+	-e TF_LOG=INFO \
+	-e TF_LOG_PATH=/brokerpak/terraform.log \
 	-e "DB_TYPE=sqlite3" \
 	-e "DB_PATH=/tmp/csb-db" \
 	--env-file .env.secrets \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ CSB_BINDING_FETCH=docker exec csb-service-$(SERVICE_NAME) ./bin/binding-fetch.sh
 INSTANCE_NAME ?= instance-$(USER)
 
 # Use these parameters when provisioning an instance
-CLOUD_PROVISION_PARAMS='{ "subdomain": "${INSTANCE_NAME}", "write_kubeconfig": "true" }'
+CLOUD_PROVISION_PARAMS='{ "subdomain": "${INSTANCE_NAME}", "write_kubeconfig": true }'
 
 # Use these parameters when creating a binding
 CLOUD_BIND_PARAMS='{}'

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ demo-up: ## Provision an EKS instance and output the bound credentials
 	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params $(CLOUD_PROVISION_PARAMS) 2>&1 > /dev/null ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding" ;\
-	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding --params $(CLOUD_BIND_PARAMS) 2>&1 > /dev/null ;\
+	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding --params $(CLOUD_BIND_PARAMS) | jq -r .response > ${INSTANCE_NAME}.binding.json ;\
 	)
 
 demo-run: ## Run tests on the demo instance
@@ -110,9 +110,7 @@ demo-run: ## Run tests on the demo instance
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Testing ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding" ;\
-	export SERVICE_INFO="$$( $(CSB_BINDING_FETCH) ${INSTANCE_NAME} binding)" ;\
-	echo ./test.sh with: ;\
-	echo ${SERVICE_INFO} ;\
+	./test.sh ${INSTANCE_NAME}.binding.json ;\
 	)
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,25 @@ CSB=ghcr.io/gsa/cloud-service-broker:v0.4.1gsa
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 
-EDEN_EXEC=eden --client user --client-secret pass --url http://127.0.0.1:8080
 SERVICE_NAME=aws-eks-service
 PLAN_NAME=raw
+
+# Execute the cloud-service-broker binary inside the running container
+CSB_EXEC=docker exec csb-service-$(SERVICE_NAME) /bin/cloud-service-broker
+
+# Generate IDs for the serviceid and planid, formatted like so (suitable for eval):
+#   serviceid=SERVICEID
+#   planid=PLANID
+CSB_SET_IDS=$(CSB_EXEC) client catalog | jq -r '.response.services[]| select(.name=="$(SERVICE_NAME)") | {serviceid: .id, planid: .plans[0].id} | to_entries | .[] | "export " + .key + "=" + (.value | @sh)'
+
+# Wait for an instance operation to complete; append with the instance id
+CSB_INSTANCE_WAIT=docker exec csb-service-$(SERVICE_NAME) ./bin/instance-wait.sh
+
+# Wait for an binding operation to complete; append with the instance id and binding id
+CSB_BINDING_WAIT=docker exec csb-service-$(SERVICE_NAME) ./bin/binding-wait.sh
+
+# Fetch the content of a binding; append with the instance id and binding id
+CSB_BINDING_FETCH=docker exec csb-service-$(SERVICE_NAME) ./bin/binding-fetch.sh
 
 # Use the env var INSTANCE_NAME for the name of the instance to be created, or
 # "instance-$USER" if it was not specified. 
@@ -21,10 +37,13 @@ PLAN_NAME=raw
 # invocations, and make it obvious which resources correspond to which CI run.
 INSTANCE_NAME ?= instance-$(USER)
 
-CLOUD_PROVISION_PARAMS="{ \"subdomain\": \"${INSTANCE_NAME}\" }"
-CLOUD_BIND_PARAMS="{}"
+# Use these parameters when provisioning an instance
+CLOUD_PROVISION_PARAMS='{ "subdomain": "${INSTANCE_NAME}", "write_kubeconfig": "true" }'
 
-PREREQUISITES = docker jq kubectl eden
+# Use these parameters when creating a binding
+CLOUD_BIND_PARAMS='{}'
+
+PREREQUISITES = docker jq kubectl
 K := $(foreach prereq,$(PREREQUISITES),$(if $(shell which $(prereq)),some string,$(error "Missing prerequisite commands $(prereq)")))
 
 clean: demo-down down ## Bring down the broker service if it's up and clean out the database
@@ -64,25 +83,49 @@ down: .env.secrets ## Bring the cloud-service-broker service down
 
 # Normally we would just run `$(CSB) client run-examples` to test the brokerpak.
 # However, some of our tests need to run between bind and unbind. So, we'll
-# provision+bind and unbind+deprovision manually with eden via "demo-up" and
+# provision+bind and unbind+deprovision manually via "demo-up" and
 # "demo-down" targets.
 test: demo-up demo-run demo-down ## Execute the brokerpak examples against the running broker
 
+check-ids:
+	@( \
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo Service ID: $$serviceid ;\
+	echo Plan ID: $$planid ;\
+	)
+
 demo-up: ## Provision an EKS instance and output the bound credentials
-	@$(EDEN_EXEC) provision -i ${INSTANCE_NAME} -s ${SERVICE_NAME}  -p ${PLAN_NAME} -P '$(CLOUD_PROVISION_PARAMS)'
-	@$(EDEN_EXEC) bind -b binding -i ${INSTANCE_NAME}
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params $(CLOUD_PROVISION_PARAMS) 2>&1 > /dev/null ;\
+	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
+	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding" ;\
+	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding --params $(CLOUD_BIND_PARAMS) 2>&1 > /dev/null ;\
+	)
 
 demo-run: ## Run tests on the demo instance
-	INSTANCE_NAME=${INSTANCE_NAME} ./test.sh
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Testing ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding" ;\
+	export SERVICE_INFO="$$( $(CSB_BINDING_FETCH) ${INSTANCE_NAME} binding)" ;\
+	echo ./test.sh with: ;\
+	echo ${SERVICE_INFO} ;\
+	)
+
 
 demo-down: ## Clean up data left over from tests and demos
-	@echo "Unbinding and deprovisioning the ${SERVICE_NAME} instance"
-	-@$(EDEN_EXEC) unbind -b binding -i ${INSTANCE_NAME} 2>/dev/null
-	-@$(EDEN_EXEC) deprovision -i ${INSTANCE_NAME} 2>/dev/null
-
-	@echo "Removing any orphan services from eden"
-	-@rm ~/.eden/config  2>/dev/null ; true
-
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding" ;\
+	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding 2>&1 > /dev/null || true ;\
+	echo "Deprovisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
+	$(CSB_EXEC) client deprovision   --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} 2>&1 > /dev/null || true ;\
+	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} || true;\
+	)
 
 all: clean build up test down ## Clean and rebuild, then bring up the server, run the examples, and bring the system down
 .PHONY: all clean build up down test demo-up demo-down test-env-up test-env-down

--- a/README.md
+++ b/README.md
@@ -58,11 +58,6 @@ building, serving, and testing the brokerpak.
 1. [`eden`](https://github.com/starkandwayne/eden) is used as a client for testing the brokerpak
 1. AWS account credentials (as environment variables) are used for actual
    service provisioning. The corresponding user must have at least the permissions described in `permission-policies.tf`. Set at least these variables:
-  
-    - AWS_ACCESS_KEY_ID
-    - AWS_SECRET_ACCESS_KEY
-    - AWS_DEFAULT_REGION
-
 
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ building, serving, and testing the brokerpak.
    this step should not be necessary in future.)
 
 1. `make` is used for executing docker commands in a meaningful build cycle.
-1. [`eden`](https://github.com/starkandwayne/eden) is used as a client for testing the brokerpak
 1. AWS account credentials (as environment variables) are used for actual
    service provisioning. The corresponding user must have at least the permissions described in `permission-policies.tf`. Set at least these variables:
 
@@ -116,7 +115,7 @@ The [examples specified by the
 brokerpak](https://github.com/pivotal/cloud-service-broker/blob/master/docs/brokerpak-specification.md#service-yaml-flie)
 will be invoked for end-to-end testing of the brokerpak's service offerings.
 
-You can also manually interact with the broker using the [`eden` OSBAPI client](https://github.com/starkandwayne/eden)
+You can also manually interact with the broker using the [`cloud-service-broker client` sub-command](https://github.com/cloudfoundry/cloud-service-broker#commands) or the [`eden` OSBAPI client](https://github.com/starkandwayne/eden)
 
 ### Shutting the brokerpak down
 

--- a/bin/binding-fetch.sh
+++ b/bin/binding-fetch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Simple script to fetch the content of "instance $1 binding $2". See OSBAPI
+# spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#fetching-a-service-binding
+# 
+# This script uses the "cloud-service-broker client fetch" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md#broker-service-configuration
+# 
+# =====> NOT YET! There's no client subcommand for getting the content of a
+# service binding, so we're just going to use that config in the environment
+# with curl.
+
+set -e
+
+curl -s "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}" -X GET -H "X-Broker-API-Version: 2.16"

--- a/bin/binding-wait.sh
+++ b/bin/binding-wait.sh
@@ -35,7 +35,7 @@ function waitLast {
             exit 0
         fi
         echo "$STATE... "
-		sleep 1
+		sleep 10
 	done
 }
 

--- a/bin/binding-wait.sh
+++ b/bin/binding-wait.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Simple script to wait for "instance $1 binding $2" to finish the current
+# operation, and report the result. See OSBAPI spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation-for-service-instances
+# 
+# This script uses the "cloud-service-broker client last" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md#broker-service-configuration
+#
+# =====> NOT YET! There's no client subcommand for getting the last operation on
+# a service binding, so we're just going to use that config in the environment with curl.
+
+set -e
+
+function getLast {
+    curl -s -I -v "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}/last_operation" -H "X-Broker-API-Version: 2.16"
+}
+
+function waitLast {
+	while true; do 
+		LAST=$(getLast "$1" "$2");
+        STATUS=$(echo "$LAST" | jq -r .status_code) 
+        STATE=$(echo "$LAST" | jq -r .response.state) 
+        if [[ $STATUS == "410" ]]; then
+            echo "gone!"
+            exit 0
+ 	    elif [[ $STATE == "failed" ]]; then
+            echo "$STATE!"
+            echo "$LAST" | jq -r .response.description
+	    exit 1
+        elif [[ $STATE == "succeeded" ]]; then
+            echo "$STATE!"
+            exit 0
+        fi
+        echo "$STATE... "
+		sleep 1
+	done
+}
+
+waitLast "$1" "$2"

--- a/bin/binding-wait.sh
+++ b/bin/binding-wait.sh
@@ -15,7 +15,7 @@
 set -e
 
 function getLast {
-    curl -s -I -v "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}/last_operation" -H "X-Broker-API-Version: 2.16"
+    curl -s "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}/last_operation" -H "X-Broker-API-Version: 2.16"
 }
 
 function waitLast {

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -30,11 +30,11 @@ function waitLast {
       exit 1
     elif [[ $STATE == "succeeded" ]]; then
       # Sometimes there is a problem even if the provision succeeded
-      echo "$LAST" | jq -r .response.description
       echo "$STATE!"
+      echo "$LAST" | jq -r .response.description
       exit 0
     fi
-    echo -ne "\r$STATE...($time seconds)"
+    echo -ne "\r$STATE | ($time seconds)..."
     time=$(($time+10))
     sleep 10
   done

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -3,7 +3,7 @@
 # Simple script to wait for instance $1 to finish the current operation, and
 # report the result. See OSBAPI spec here:
 #   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation-for-service-instances
-# 
+#
 # This script uses the "cloud-service-broker client last" subcommand, and
 # requires that the necessary environment variables are set for accessing the
 # service. See configuration documentation here:
@@ -12,28 +12,32 @@
 set -e
 
 function getLast {
-	/bin/cloud-service-broker client last --instanceid "$1"
+  /bin/cloud-service-broker client last --instanceid "$1"
 }
 
 function waitLast {
-	while true; do 
-		LAST=$(getLast "$1");
-        STATUS=$(echo "$LAST" | jq -r .status_code) 
-        STATE=$(echo "$LAST" | jq -r .response.state) 
-        if [[ $STATUS == "410" ]]; then
-            echo "gone!"
-            exit 0
- 	    elif [[ $STATE == "failed" ]]; then
-            echo "$STATE!"
-            echo "$LAST" | jq -r .response.description
-	    exit 1
-        elif [[ $STATE == "succeeded" ]]; then
-            echo "$STATE!"
-            exit 0
-        fi
-        echo "$STATE... "
-		sleep 10
-	done
+  time=0
+  while true; do
+    LAST=$(getLast "$1");
+    STATUS=$(echo "$LAST" | jq -r .status_code)
+    STATE=$(echo "$LAST" | jq -r .response.state)
+    if [[ $STATUS == "410" ]]; then
+      echo "gone!"
+      exit 0
+    elif [[ $STATE == "failed" ]]; then
+      echo "$STATE!"
+      echo "$LAST" | jq -r .response.description
+      exit 1
+    elif [[ $STATE == "succeeded" ]]; then
+      # Sometimes there is a problem even if the provision succeeded
+      echo "$LAST" | jq -r .response.description
+      echo "$STATE!"
+      exit 0
+    fi
+    echo -ne "\r$STATE...($time seconds)"
+    time=$(($time+10))
+    sleep 10
+  done
 }
 
 waitLast "$1"

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Simple script to wait for instance $1 to finish the current operation, and
+# report the result. See OSBAPI spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation-for-service-instances
+# 
+# This script uses the "cloud-service-broker client last" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md
+
+set -e
+
+function getLast {
+	/bin/cloud-service-broker client last --instanceid "$1"
+}
+
+function waitLast {
+	while true; do 
+		LAST=$(getLast "$1");
+        STATUS=$(echo "$LAST" | jq -r .status_code) 
+        STATE=$(echo "$LAST" | jq -r .response.state) 
+        if [[ $STATUS == "410" ]]; then
+            echo "gone!"
+            exit 0
+ 	    elif [[ $STATE == "failed" ]]; then
+            echo "$STATE!"
+            echo "$LAST" | jq -r .response.description
+	    exit 1
+        elif [[ $STATE == "succeeded" ]]; then
+            echo "$STATE!"
+            exit 0
+        fi
+        echo "$STATE... "
+		sleep 1
+	done
+}
+
+waitLast "$1"

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -21,8 +21,8 @@ function waitLast {
     LAST=$(getLast "$1");
     STATUS=$(echo "$LAST" | jq -r .status_code)
     STATE=$(echo "$LAST" | jq -r .response.state)
-    if [[ "$(echo "$LAST" | jq -r .response.state)" != "null" ]]; then
-      ACTION=$(echo "$LAST" | jq -r .response.state)
+    if [[ "$(echo "$LAST" | jq -r .response.description)" != "null" ]]; then
+      ACTION=$(echo "$LAST" | jq -r .response.description)
     fi
     if [[ $STATUS == "410" ]]; then
       echo "gone!"

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -21,17 +21,20 @@ function waitLast {
     LAST=$(getLast "$1");
     STATUS=$(echo "$LAST" | jq -r .status_code)
     STATE=$(echo "$LAST" | jq -r .response.state)
+    if [[ "$(echo "$LAST" | jq -r .response.state)" != "null" ]]; then
+      ACTION=$(echo "$LAST" | jq -r .response.state)
+    fi
     if [[ $STATUS == "410" ]]; then
       echo "gone!"
       exit 0
     elif [[ $STATE == "failed" ]]; then
       echo "$STATE!"
-      echo "$LAST" | jq -r .response.description
+      echo "$ACTION"
       exit 1
     elif [[ $STATE == "succeeded" ]]; then
       # Sometimes there is a problem even if the provision succeeded
       echo "$STATE!"
-      echo "$LAST" | jq -r .response.description
+      echo "$ACTION"
       exit 0
     fi
     echo -ne "\r$STATE | ($time seconds)..."

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -32,7 +32,7 @@ function waitLast {
             exit 0
         fi
         echo "$STATE... "
-		sleep 1
+		sleep 10
 	done
 }
 

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -32,7 +32,7 @@ provision:
     details: A subdomain to use for the cluster instance. Default is the instance ID. Make sure the name meets AWS requirements (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
   - field_name: write_kubeconfig
     type: boolean
-    details: "Specify whether the cluster kubeconfig is made available as an output"
+    details: "Specify whether the cluster kubeconfig is written during provisioning. (This is an operator debugging aid.)"
   - field_name: mng_desired_capacity
     required: false
     type: number

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -17,10 +17,6 @@ resource "helm_release" "zookeeper-operator" {
     name  = "hooks.delete"
     value = "false"
   }
-
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }
 
 # TODO: Figure out how we can non-destructively update the CRDs from the
@@ -46,9 +42,5 @@ resource "helm_release" "solr-operator" {
     name  = "zookeeper-operator.install"
     value = "false"
   }
-
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -182,7 +182,7 @@ resource "aws_eks_fargate_profile" "default_namespaces" {
   depends_on = [module.eks.cluster_id]
 }
 
-# We use this null_resource to ensure that the Kubernetes provider is not
+# We use this null_resource to ensure that the Kubernetes and helm providers are not
 # actually exercised before the cluster is fully available. This averts
 # race-cases between the kubernetes provider and the aws provider as a general
 # class of problem.
@@ -191,7 +191,7 @@ resource "null_resource" "cluster-functional" {
   depends_on = [
     null_resource.prerequisite_binaries_present,
     module.eks.cluster_id,
-    module.eks.aws_eks_node_group
+    module.eks.eks_managed_node_groups
   ]
 }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -222,8 +222,14 @@ resource "null_resource" "cluster-functional" {
 # data sources so the cluster will be up and ready first
 data "aws_eks_cluster" "main" {
   name = module.eks.cluster_id
+  depends_on = [
+    null_resource.cluster-functional
+  ]
 }
 
 data "aws_eks_cluster_auth" "main" {
   name = module.eks.cluster_id
+  depends_on = [
+    null_resource.cluster-functional
+  ]
 }

--- a/terraform/provision/external-dns.tf
+++ b/terraform/provision/external-dns.tf
@@ -67,9 +67,6 @@ resource "kubernetes_service_account" "external_dns" {
     }
   }
   automount_service_account_token = true
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }
 
 resource "kubernetes_cluster_role" "external_dns" {
@@ -92,9 +89,6 @@ resource "kubernetes_cluster_role" "external_dns" {
     resources  = ["gateways"]
     verbs      = ["get", "list", "watch"]
   }
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }
 
 resource "kubernetes_cluster_role_binding" "external_dns" {
@@ -111,9 +105,6 @@ resource "kubernetes_cluster_role_binding" "external_dns" {
     name      = kubernetes_service_account.external_dns.metadata.0.name
     namespace = kubernetes_service_account.external_dns.metadata.0.namespace
   }
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }
 
 # Chart docs: https://github.com/bitnami/charts/tree/master/bitnami/external-dns/
@@ -146,7 +137,4 @@ resource "helm_release" "external_dns" {
       value = set.value
     }
   }
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -97,7 +97,6 @@ resource "helm_release" "ingress_nginx" {
     VALUES
   ]
   depends_on = [
-    null_resource.cluster-functional,
     module.aws_load_balancer_controller,
     time_sleep.alb_controller_destroy_delay
   ]

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -25,6 +25,9 @@ module "aws_load_balancer_controller" {
     null_resource.cluster-functional,
   ]
   aws_tags = merge(var.labels, { "domain" = local.domain })
+  depends_on = [
+    null_resource.cluster-functional
+  ]
 }
 
 # ---------------------------------------------------------
@@ -97,6 +100,7 @@ resource "helm_release" "ingress_nginx" {
     VALUES
   ]
   depends_on = [
+    null_resource.cluster-functional,
     module.aws_load_balancer_controller,
     time_sleep.alb_controller_destroy_delay
   ]

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -41,7 +41,8 @@ resource "helm_release" "ingress_nginx" {
 
   namespace       = "kube-system"
   cleanup_on_fail = "true"
-  atomic          = "true"
+  # TODO: Figure out if we actually need this to be atomic
+  # atomic          = "true"
   timeout         = 600
 
   dynamic "set" {
@@ -112,7 +113,7 @@ resource "helm_release" "ingress_nginx" {
 # a depends_on in order to ensure an orderly destroy!
 resource "time_sleep" "alb_controller_destroy_delay" {
   depends_on       = [module.aws_load_balancer_controller]
-  destroy_duration = "30s"
+  destroy_duration = "60s"
 }
 
 

--- a/terraform/provision/logging.tf
+++ b/terraform/provision/logging.tf
@@ -67,7 +67,4 @@ resource "null_resource" "namespace_fargate_logging" {
       kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
     EOF
   }
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }

--- a/terraform/provision/persistent-storage.tf
+++ b/terraform/provision/persistent-storage.tf
@@ -218,4 +218,7 @@ resource "kubernetes_storage_class" "ebs-sc" {
   # https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
   storage_provisioner    = "kubernetes.io/aws-ebs"
   allow_volume_expansion = true
+  depends_on = [
+    null_resource.cluster-functional
+  ]
 }

--- a/terraform/provision/persistent-storage.tf
+++ b/terraform/provision/persistent-storage.tf
@@ -218,7 +218,4 @@ resource "kubernetes_storage_class" "ebs-sc" {
   # https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
   storage_provisioner    = "kubernetes.io/aws-ebs"
   allow_volume_expansion = true
-  depends_on = [
-    null_resource.cluster-functional
-  ]
 }

--- a/terraform/provision/rbac.tf
+++ b/terraform/provision/rbac.tf
@@ -12,8 +12,4 @@ resource "kubernetes_role" "namespace_admin" {
     resources  = ["*"]
     verbs      = ["*"]
   }
-
-  depends_on = [
-    null_resource.cluster-functional,
-  ]
 }

--- a/test.sh
+++ b/test.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
 
 # Test that a provisioned instance is set up properly and meets requirements 
+#   ./test.sh BINDINGINFO.json
+# 
 # Returns 0 (if all tests PASS)
 #      or 1 (if any test FAILs).
 
 set -e
 retval=0
 
-#  If SERVICE_INFO is not already set in the environment, error out
-if [[ -z ${SERVICE_INFO+x} ]] ; then
+if [[ -z ${1+x} ]] ; then
+    echo "Usage: ./test.sh BINDINGINFO.json"
     exit 1
 fi
 
+SERVICE_INFO="$(cat $1 | jq -r .credentials)"
+
 # Set up the kubeconfig
 export KUBECONFIG=$(mktemp)
-${SERVICE_INFO} | jq -r '.kubeconfig' > ${KUBECONFIG}
-export DOMAIN_NAME=$(${SERVICE_INFO} | jq -r '.domain_name')
+echo "$SERVICE_INFO" | jq -r '.kubeconfig' > ${KUBECONFIG}
+export DOMAIN_NAME=$(echo "$SERVICE_INFO" | jq -r '.domain_name')
+
 
 echo "To work directly with the instance:"
 echo "export KUBECONFIG=${KUBECONFIG}"

--- a/test.sh
+++ b/test.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-# Test that the a provisioned instance is set up properly and meets requirements 
+# Test that a provisioned instance is set up properly and meets requirements 
 # Returns 0 (if all tests PASS)
 #      or 1 (if any test FAILs).
 
 set -e
 retval=0
 
-export SERVICE_INFO=$(echo "eden --client user --client-secret pass --url http://127.0.0.1:8080 credentials -b binding -i ${INSTANCE_NAME:-instance-${USER}}")
+#  If SERVICE_INFO is not already set in the environment, error out
+if [[ -z ${SERVICE_INFO+x} ]] ; then
+    exit 1
+fi
 
 # Set up the kubeconfig
 export KUBECONFIG=$(mktemp)


### PR DESCRIPTION
In case kubenetes tries to create the storage class before the cluster is actually functional (i.e. node groups coming up or some other race condition), wait until we know the cluster is more ready

Related to, 
```
Error: Error: Post "https://3ecc6d85ff42f6acfd57348528412984.gr7.us-west-2.eks.amazonaws.com/apis/storage.k8s.io/v1/storageclasses": dial tcp 100.20.251.29:443: i/o timeout  with kubernetes_storage_class.ebs-sc,  on persistent-storage.tf line 209, in resource "kubernetes_storage_class" "ebs-sc": 209: resource "kubernetes_storage_class" "ebs-sc" { exit status 1
```