### PR TITLE
Add support for Bind Module Reference

### DIFF
--- a/terraform/bind/versions.tf
+++ b/terraform/bind/versions.tf
@@ -16,5 +16,5 @@ terraform {
       source = "hashicorp/template"
     }
   }
-  required_version = ">= 0.13"
+  required_version = "~> 1.1.5"
 }


### PR DESCRIPTION
Getting error 'Module module.brokerpak-eks-terraform-bind contains provider configuration' in ssb broker

![image](https://user-images.githubusercontent.com/85196563/154772337-24a31707-e8fc-4314-abd7-aa65b6250f92.png)
