### PR TITLE
Make `terraform destroy` reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,22 @@ brokerpak concept, and to the Pivotal team running with the concept!
 
 Each brokered AWS EKS provides:
 
-- unique, isolated VPC with multiple AZs
-- Kubernetes nodes provided by AWS EKS Fargate
-- Bound credential permissions are limited by namespace
-- cluster-wide logging to AWS CloudWatch with fluent-bit
-- Automatic TLS configuration using AWS Certificate Manager (ACM)
-- Load Balancing Capabilities:
-  - [Current] Using the NLB functionality requires that you also install the [AWS VPC CNI add-on](https://github.com/GSA/datagov-brokerpak-eks/pull/69/files#diff-54dc6204ad9b3495e7157b5dab706ac9b1e4f19d69f127eec9959e80e2b0aa93R34-R37)
-    - This can be managed by this module through setting `install_vpc_cni` to `1`
-  - [Deprecated] Cluster-wide ingress load-balancing with AWS-specific features (eg WAFv2 integration) [via ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)
-- nginx ingress controller for routing and IaaS-independent deployments
-- Automatic DNSSEC configuration for the cluster using AWS Route 53
-- Automatic DNS configuration for workloads using AWS Route53 [via ExternalDNS](https://github.com/kubernetes-sigs/external-dns)
-- [Persistent Volumes using AWS EFS](https://aws.amazon.com/blogs/aws/new-aws-fargate-for-amazon-eks-now-supports-amazon-efs/)
+- Kubernetes cluster spanning multiple AZs (AWS VPC)
+- Managed nodes (AWS EC2)
+- Twice-hourly scanning and daily patching of nodes (AWS Inspector and AWS SSM)
+- Control plane and workload logging with fluent-bit (AWS CloudWatch)
+- A single Load Balancer per cluster (AWS Network Load Balancer)
+- Automatic DNS and DNSSEC configuration for the cluster and workloads with
+  [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) (AWS Route 53)
+- IaaS-independent deployments using nginx ingress controller
+- Automatic TLS configuration and 80->443 redirect (AWS Certificate Manager)
+- Dynamic persistent Volumes (AWS EBS and AWS EBS-CSI)
+- Network Policy support with default-deny egress (AWS VPC-CNI and Calico)
 - [ZooKeeper CRDs](https://github.com/pravega/zookeeper-operator) ready for
   managing Apache ZooKeeper clusters
-- [Solr CRDs](https://github.com/apache/solr-operator) for managing
-  SolrCloud instances
+- [Solr CRDs](https://github.com/apache/solr-operator) for managing SolrCloud
+  instances
+- Each binding generates a unique namespace-limited credential
 
 ## Development Prerequisites
 

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -295,6 +295,9 @@ resource "null_resource" "cluster-functional" {
     null_resource.prerequisite_binaries_present,
     module.eks.cluster_id,
     module.eks.eks_managed_node_groups,
+    module.eks.aws_eks_addon,
+    module.eks,
+    module.vpc
     # We could include module.eks.fargate_profiles here, but realistically
     # Fargate doesn't have to be ready as long as the node group is ready.
   ]

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -104,7 +104,7 @@ resource "helm_release" "ingress_nginx" {
   depends_on = [
     null_resource.cluster-functional,
     module.aws_load_balancer_controller,
-    time_sleep.alb_controller_destroy_delay
+    time_sleep.delay_alb_controller_destroy
   ]
 }
 
@@ -112,7 +112,7 @@ resource "helm_release" "ingress_nginx" {
 # removed and an ALB needs to be deleted) before actually removing it. Any
 # Ingress or Service:LoadBalancer resource created in future should add this as
 # a depends_on in order to ensure an orderly destroy!
-resource "time_sleep" "alb_controller_destroy_delay" {
+resource "time_sleep" "delay_alb_controller_destroy" {
   depends_on       = [module.aws_load_balancer_controller]
   destroy_duration = "60s"
 }

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -53,4 +53,7 @@ resource "helm_release" "calico" {
   repository = "https://docs.projectcalico.org/charts"
   chart      = "tigera-operator"
   version    = "v3.22.1"
+  depends_on = [
+    null_resource.cluster-functional
+  ]
 }

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -47,7 +47,7 @@ resource "kubernetes_network_policy" "default-deny" {
 
 resource "helm_release" "calico" {
   name       = "calico"
-  namespace  = "calico-system"
+  namespace  = kubernetes_namespace.calico-system.id
   wait       = true
   atomic     = true
   repository = "https://docs.projectcalico.org/charts"


### PR DESCRIPTION
Introduce dependencies that enable reliable `terraform destroy`.

Note the depends_on in k8s-network-policy.tf introduces an explicit dependency between code in the provision-aws and provision-k8s modules. See the comment on that commit for discussion.

Related to https://github.com/gsa/data.gov/issues/3617