### PR TITLE
Single AZ Support

### DIFF
--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -49,6 +49,10 @@ provision:
     required: false
     type: array
     details: "A list of the desired AWS Compute types that the nodes will be launched with (e.g. [\"m5.large\"])"
+  - field_name: single_az
+    required: false
+    type: boolean
+    details: "Specify whether the managed node group should span only a single availability zone"
 
   computed_inputs:
   - name: instance_name
@@ -89,9 +93,9 @@ provision:
     type: array
     default: ["m5.large"]
     overwrite: true
-  - name: install_vpc_cni
+  - name: single_az
     type: boolean
-    default: true
+    default: false
     overwrite: true
 
   outputs:

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -109,6 +109,7 @@ module "eks" {
       launch_template_name = "${local.cluster_name}-lt"
       name                 = "${local.cluster_name}"
       ami_id               = data.aws_ami.gsa-ise.id
+      subnet_ids           = var.single_az ? [module.vpc.private_subnets[0]] : module.vpc.private_subnets
 
       enable_bootstrap_user_data = true
       bootstrap_extra_args       = "--container-runtime dockerd"
@@ -309,10 +310,10 @@ data "template_file" "kubeconfig" {
 
 resource "local_sensitive_file" "kubeconfig" {
   # Only create the file if requested; it's not needed by provisioners
-  count             = var.write_kubeconfig ? 1 : 0
-  content           = data.template_file.kubeconfig.rendered
-  filename          = local.kubeconfig_name
-  file_permission   = "0600"
+  count           = var.write_kubeconfig ? 1 : 0
+  content         = data.template_file.kubeconfig.rendered
+  filename        = local.kubeconfig_name
+  file_permission = "0600"
 }
 
 

--- a/terraform/modules/provision-aws/variables.tf
+++ b/terraform/modules/provision-aws/variables.tf
@@ -45,3 +45,8 @@ variable "write_kubeconfig" {
   type    = bool
   default = false
 }
+
+variable "single_az" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/provision-k8s/k8s-persistent-storage.tf
+++ b/terraform/modules/provision-k8s/k8s-persistent-storage.tf
@@ -11,4 +11,18 @@ resource "kubernetes_storage_class" "ebs-sc" {
   # https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
   storage_provisioner    = "kubernetes.io/aws-ebs"
   allow_volume_expansion = true
+
+  # Ensure volumes are created in the correct topology (specifically availability zone)
+  # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
+  volume_binding_mode    = "WaitForFirstConsumer"
+
+  allowed_topologies {
+    dynamic "match_label_expressions" {
+      for_each = var.single_az ? [1] : []
+      content {
+        key    = "topology.ebs.csi.aws.com/zone"
+        values = ["${var.region}a"]
+      }
+    }
+  }
 }

--- a/terraform/modules/provision-k8s/k8s-persistent-storage.tf
+++ b/terraform/modules/provision-k8s/k8s-persistent-storage.tf
@@ -16,6 +16,10 @@ resource "kubernetes_storage_class" "ebs-sc" {
   # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
   volume_binding_mode    = "WaitForFirstConsumer"
 
+  # The following code uses an optional nested block to define EBS volume parameters
+  # References:
+  # - https://codeinthehole.com/tips/conditional-nested-blocks-in-terraform/
+  # - https://medium.com/@business_99069/terraform-0-12-conditional-block-7d166e4abcbf
   allowed_topologies {
     dynamic "match_label_expressions" {
       for_each = var.single_az ? [1] : []


### PR DESCRIPTION
This allows users to specify that the entire workload should be run within a single AWS Availability Zone for latency or other operational requirements.

New Additions:
- Restrict Managed Node Group Node Creation to a single availability zone if `single_az = true`
- Change volume binding for storage class to `"WaitForFirstConsumer"` to ensure it can be attached to nodes with the correct topology (specifically, within the same availability zone)

This is not the most optimal solution (primarily just a quick workaround).  Things that must be considered long-term is auto-scaling specification to ensure new nodes are only created within the same existing availability zone and there aren't any other edge cases to consider.  By forcing the managed node group to live within a single subnet, it forces nodes to be assigned solely to that subnet's availability zone.

References for creating an optional nested block: 
- https://codeinthehole.com/tips/conditional-nested-blocks-in-terraform/
- https://medium.com/@business_99069/terraform-0-12-conditional-block-7d166e4abcbf

Additional Background surrounding Storage Classes:
> A cluster administrator can address this issue by specifying the WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a Pod using the PersistentVolumeClaim is created. PersistentVolumes will be selected or provisioned conforming to the topology that is specified by the Pod's scheduling constraints. These include, but are not limited to, resource requirements, [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), pod affinity and anti-affinity, and [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration).

If a PV is scheduled in `AZ A` and a pod requires that PV and there are no available nodes in `AZ A` because new pods were higher in the scheduling queue.  The pod will be stuck in a pending state until a node becomes available in `AZ A` where it's already provisioned volume exists.  By setting "WaitForFirstConsumer " on the storage class, the PV won't be provisioned until the pod is scheduled and it's state is known to create a volume compatible with it.