### PR TITLE
Make using the GSA AMI optional with a variable

### DIFF
--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -85,6 +85,10 @@ provision:
     type: number
     default: 1
     overwrite: true
+  - name: use_hardened_ami
+    type: boolean
+    default: false
+    overwrite: true
   - name: mng_min_capacity
     type: number
     default: 1

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -30,6 +30,10 @@ provision:
       pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
     default: ${str.truncate(64, "${request.instance_id}")}
     details: A subdomain to use for the cluster instance. Default is the instance ID. Make sure the name meets AWS requirements (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
+  - field_name: use_hardened_ami
+    type: boolean
+    required: false
+    details: "Specify whether we want to use the GSA hardened AMI."
   - field_name: write_kubeconfig
     type: boolean
     details: "Specify whether the cluster kubeconfig is written during provisioning. (This is an operator debugging aid.)"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -101,6 +101,7 @@ module "provision-aws" {
   mng_min_capacity     = var.mng_min_capacity
   mng_max_capacity     = var.mng_max_capacity
   mng_desired_capacity = var.mng_desired_capacity
+  use_hardened_ami     = var.use_hardened_ami
   region               = var.region
   subdomain            = var.subdomain
   write_kubeconfig     = var.write_kubeconfig

--- a/terraform/modules/provision-aws/README.md
+++ b/terraform/modules/provision-aws/README.md
@@ -32,7 +32,7 @@ the broker context here.
    here carry some of your environment variables into that shell, and ensure
    that you'll have permission to remove any files that get created.
 
-   *Note*: If your account does not have access to the GSA hardened AMIs, you will need to run Terraform plans and applies with the variable `use_hardened_ami` set to `False` like so: `terraform plan -var 'use_hardened_ami=false'`
+   *Note*: If your account does not have access to the CIS-hardened managed nodes ([GSA ISE](https://github.com/GSA/odp-jenkins-hardening-pipeline), AWS EC2), you will need to run Terraform plans and applies with the variable `use_hardened_ami` set to `False` like so: `terraform plan -var 'use_hardened_ami=false'`
 
     ```bash
     $ docker run -v `pwd`/..:`pwd`/.. -w `pwd` -e HOME=`pwd` --user $(id -u):$(id -g) -e TERM -it --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION eks-provision:latest

--- a/terraform/modules/provision-aws/README.md
+++ b/terraform/modules/provision-aws/README.md
@@ -32,11 +32,14 @@ the broker context here.
    here carry some of your environment variables into that shell, and ensure
    that you'll have permission to remove any files that get created.
 
+   *Note*: If your account does not have access to the GSA hardened AMIs, you will need to run Terraform plans and applies with the variable `use_hardened_ami` set to `False` like so: `terraform plan -var 'use_hardened_ami=false'`
+
     ```bash
     $ docker run -v `pwd`/..:`pwd`/.. -w `pwd` -e HOME=`pwd` --user $(id -u):$(id -g) -e TERM -it --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION eks-provision:latest
 
     [within the container]
     terraform init
+    terraform plan
     terraform apply -auto-approve
     [tinker in your editor, run terraform apply, inspect the cluster, repeat]
     terraform destroy -auto-approve

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -5,6 +5,7 @@ locals {
 }
 
 data "aws_ami" "gsa-ise" {
+  count = var.use_hardened_ami ? 1 : 0
   owners      = ["self", "752281881774", "821341638715"]
   most_recent = true
   filter {
@@ -108,8 +109,8 @@ module "eks" {
     system = {
       launch_template_name = "${local.cluster_name}-lt"
       name                 = "${local.cluster_name}"
-      ami_id               = data.aws_ami.gsa-ise.id
       subnet_ids           = var.single_az ? [module.vpc.private_subnets[0]] : module.vpc.private_subnets
+      ami_id               = var.use_hardened_ami ? data.aws_ami.gsa-ise[0].id : null
 
       enable_bootstrap_user_data = true
       bootstrap_extra_args       = "--container-runtime dockerd"

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 data "aws_ami" "gsa-ise" {
-  count = var.use_hardened_ami ? 1 : 0
+  count       = var.use_hardened_ami ? 1 : 0
   owners      = ["self", "752281881774", "821341638715"]
   most_recent = true
   filter {

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -112,9 +112,9 @@ module "eks" {
       subnet_ids           = var.single_az ? [module.vpc.private_subnets[0]] : module.vpc.private_subnets
       ami_id               = var.use_hardened_ami ? data.aws_ami.gsa-ise[0].id : null
 
-      enable_bootstrap_user_data = true
-      bootstrap_extra_args       = "--container-runtime dockerd"
-      pre_bootstrap_user_data    = <<-EOT
+      enable_bootstrap_user_data = var.use_hardened_ami ? true : false
+      bootstrap_extra_args       = var.use_hardened_ami ? "--container-runtime dockerd" : ""
+      pre_bootstrap_user_data    = !var.use_hardened_ami ? "" : <<-EOT
         export CONTAINER_RUNTIME="dockerd"
         export USE_MAX_PODS=false
       EOT

--- a/terraform/modules/provision-aws/variables.tf
+++ b/terraform/modules/provision-aws/variables.tf
@@ -1,5 +1,5 @@
 variable "use_hardened_ami" {
-  type = bool
+  type    = bool
   default = true
 }
 

--- a/terraform/modules/provision-aws/variables.tf
+++ b/terraform/modules/provision-aws/variables.tf
@@ -1,3 +1,8 @@
+variable "use_hardened_ami" {
+  type = bool
+  default = true
+}
+
 variable "subdomain" {
   type    = string
   default = ""


### PR DESCRIPTION
Our AWS account does not yet have permission to pull the GSA hardened AMIs so we get an error when running the plan for this Terraform. When running with the variable created here set to false, we get a clean plan. 

cc/ @mogul 