### PR TITLE
Allow for multiple levels of subdomain in the certificate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         if [[ "$(echo -n ${INSTANCE_NAME} | wc -c)" -lt  "64" ]]; then
           INSTANCE_NAME="${INSTANCE_NAME}-a-long-suffix-to-ensure-we-are-generating-ids-that-are-short-enough-for-underlying-identifiers"
           INSTANCE_NAME="${INSTANCE_NAME//-}"
-          INSTANCE_NAME=$(head -c 64 <<< "$INSTANCE_NAME")
+          INSTANCE_NAME=$(head -c 58 <<< "$INSTANCE_NAME")
         fi
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -175,7 +175,9 @@ resource "aws_acm_certificate" "cert" {
   domain_name = local.domain
   # See https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html#alternative-domains-dns-validation-with-route-53
   subject_alternative_names = [
-    "*.${local.domain}"
+    "*.${local.domain}",
+    "*.*.${local.domain}",
+    "*.*.*.${local.domain}"
   ]
   validation_method = "DNS"
   tags = merge(var.labels, {


### PR DESCRIPTION
Some Helm charts might deploy services multiple subdomains deep. This change just adds SANs with additional levels of wildcarding to allow for that possibility.

(Discovered when we did a Helm install of the GitLab chart... This was literally the only thing we ran into!)