### PR TITLE
Make GSA-Hardened AMI optional (copy)

### DIFF
--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -30,6 +30,10 @@ provision:
       pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
     default: ${str.truncate(64, "${request.instance_id}")}
     details: A subdomain to use for the cluster instance. Default is the instance ID. Make sure the name meets AWS requirements (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
+  - field_name: use_hardened_ami
+    type: boolean
+    required: false
+    details: "Specify whether we want to use the GSA hardened AMI."
   - field_name: write_kubeconfig
     type: boolean
     details: "Specify whether the cluster kubeconfig is written during provisioning. (This is an operator debugging aid.)"
@@ -80,6 +84,10 @@ provision:
   - name: mng_desired_capacity
     type: number
     default: 1
+    overwrite: true
+  - name: use_hardened_ami
+    type: boolean
+    default: false
     overwrite: true
   - name: mng_min_capacity
     type: number

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -101,6 +101,7 @@ module "provision-aws" {
   mng_min_capacity     = var.mng_min_capacity
   mng_max_capacity     = var.mng_max_capacity
   mng_desired_capacity = var.mng_desired_capacity
+  use_hardened_ami     = var.use_hardened_ami
   region               = var.region
   subdomain            = var.subdomain
   write_kubeconfig     = var.write_kubeconfig

--- a/terraform/modules/provision-aws/README.md
+++ b/terraform/modules/provision-aws/README.md
@@ -32,11 +32,14 @@ the broker context here.
    here carry some of your environment variables into that shell, and ensure
    that you'll have permission to remove any files that get created.
 
+   *Note*: If your account does not have access to the CIS-hardened managed nodes ([GSA ISE](https://github.com/GSA/odp-jenkins-hardening-pipeline), AWS EC2), you will need to run Terraform plans and applies with the variable `use_hardened_ami` set to `False` like so: `terraform plan -var 'use_hardened_ami=false'`
+
     ```bash
     $ docker run -v `pwd`/..:`pwd`/.. -w `pwd` -e HOME=`pwd` --user $(id -u):$(id -g) -e TERM -it --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION eks-provision:latest
 
     [within the container]
     terraform init
+    terraform plan
     terraform apply -auto-approve
     [tinker in your editor, run terraform apply, inspect the cluster, repeat]
     terraform destroy -auto-approve

--- a/terraform/modules/provision-aws/variables.tf
+++ b/terraform/modules/provision-aws/variables.tf
@@ -1,3 +1,8 @@
+variable "use_hardened_ami" {
+  type    = bool
+  default = true
+}
+
 variable "subdomain" {
   type    = string
   default = ""


### PR DESCRIPTION
Would supersede #94 (if successful)
This is a test to see if the tests will start if the same PR is from data.gov as opposed to from a fork.