### PR TITLE
Restrict Ingress to Cloud.gov by default

### DIFF
--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -5,4 +5,5 @@ locals {
   zone_id                    = aws_route53_zone.cluster.zone_id
   zone_role_arn              = aws_iam_role.external_dns.arn
   launch_template_name       = data.aws_launch_template.eks_launch_template.name
+  vpc_cidr_range             = module.vpc.vpc_cidr_block
 }

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -58,7 +58,7 @@ resource "kubernetes_network_policy" "default" {
     ingress {
       from {
         ip_block {
-          cidr = local.vpc_cidr_block
+          cidr = local.vpc_cidr_range
         }
       }
       from {

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -58,7 +58,7 @@ resource "kubernetes_network_policy" "default" {
     ingress {
       from {
         ip_block {
-          cidr = "10.31.0.0/16"
+          cidr = local.vpc_cidr_block
         }
       }
       from {

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -58,10 +58,14 @@ resource "kubernetes_network_policy" "default" {
     ingress {
       from {
         ip_block {
+          cidr = "10.31.0.0/16"
+        }
+      }
+      from {
+        ip_block {
           cidr = "52.222.122.97/32"
         }
       }
-
       from {
         ip_block {
           cidr = "52.222.123.172/32"

--- a/terraform/modules/provision-k8s/k8s-persistent-storage.tf
+++ b/terraform/modules/provision-k8s/k8s-persistent-storage.tf
@@ -14,7 +14,7 @@ resource "kubernetes_storage_class" "ebs-sc" {
 
   # Ensure volumes are created in the correct topology (specifically availability zone)
   # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
-  volume_binding_mode    = "WaitForFirstConsumer"
+  volume_binding_mode = "WaitForFirstConsumer"
 
   # The following code uses an optional nested block to define EBS volume parameters
   # References:

--- a/terraform/modules/provision-k8s/standalone-variables.tf
+++ b/terraform/modules/provision-k8s/standalone-variables.tf
@@ -47,6 +47,10 @@ variable "launch_template_name" {
   type = string
 }
 
+variable "vpc_cidr_range" {
+  type = string
+}
+
 locals {
   certificate_authority_data = var.certificate_authority_data
   cluster_name               = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
@@ -57,4 +61,5 @@ locals {
   zone_id                    = var.zone_id
   zone_role_arn              = var.zone_role_arn
   launch_template_name       = var.launch_template_name
+  vpc_cidr_range             = var.vpc_cidr_range
 }

--- a/test.sh
+++ b/test.sh
@@ -28,6 +28,11 @@ echo "export KUBECONFIG=${KUBECONFIG}"
 echo "export DOMAIN_NAME=${DOMAIN_NAME}"
 echo "Running tests..."
 
+# Test Setup - Allow test script to access cluster
+TEST_IP=`curl ifconfig.me`
+sed -i "s/<github-ip>/$TEST_IP\/32/" test_specs/networkpolicy/allow_github.yml
+kubectl apply -f test_specs/networkpolicy/allow_github.yml
+
 # Test 1
 echo "Deploying the test fixture..."
 export SUBDOMAIN=subdomain-2048

--- a/test.sh
+++ b/test.sh
@@ -233,6 +233,10 @@ rm "${KUBECONFIG}"
 KUBECONFIG=$(mktemp)
 export KUBECONFIG
 
+# Temporary Fix for https://github.com/aws/aws-cli/issues/6920
+# Solution: https://github.com/aws/aws-cli/issues/6920#issuecomment-1121390562
+pip3 install awscli --upgrade --user
+
 # Since we expect AWS creds are already set in the environment to a user for the broker to use, we
 # can use this command to generate the admin kubeconfig
 aws eks update-kubeconfig --kubeconfig "$KUBECONFIG" --name "$CLUSTER_NAME" 

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Test that a provisioned instance is set up properly and meets requirements 
+# Test that a provisioned instance is set up properly and meets requirements
 #   ./test.sh BINDINGINFO.json
-# 
+#
 # Returns 0 (if all tests PASS)
 #      or 1 (if any test FAILs).
 
@@ -103,8 +103,8 @@ TESTFIXTURE
 # external-dns to make the Route 53 entry for that subdomain, and for that
 # record to propagate. By waiting here, we are testing that both the
 # ingress-nginx controller and external-dns are working correctly.
-# 
-# Notes: 
+#
+# Notes:
 #   - host and dig are not available in the CSB container, but nslookup is.
 #   - We have found that the propagation speed for both the CNAME and DS record
 #     can be v-e-r-y s-l-o-w and depend a lot on your DNS provider. Which is why
@@ -142,9 +142,9 @@ while true; do
   echo -ne "\r($time seconds) ..."
 done
 
-# timeout(): Test whether a command finishes before a deadline 
+# timeout(): Test whether a command finishes before a deadline
 # Usage:
-#   timeout <cmd...> 
+#   timeout <cmd...>
 # Optionally, set TIMEOUT_DEADLINE_SECS to something other than the default 65s.
 # You may want to wrap more complex commands in a function and pass that.
 #
@@ -152,11 +152,11 @@ done
 # http://blog.mediatribe.net/fr/node/72/index.html
 function timeout () {
     local timeout=${TIMEOUT_DEADLINE_SECS:-65}
-    "$@" 2>/dev/null & 
+    "$@" 2>/dev/null &
     sleep "${timeout}"
     # If the process has already exited, kill returns a non-zero exit status If
     # the process hasn't already exited, kill returns a zero exit status
-    if kill $! > /dev/null 2>&1 
+    if kill $! > /dev/null 2>&1
     then
         # The command was still running at the deadline and had to be killed
         echo "The command did NOT exit within ${timeout} seconds."
@@ -171,28 +171,28 @@ function timeout () {
 # or the process is killed. timeout() will complain if it takes longer than 65
 # seconds to end on its own.
 echo -n "Testing that connections are closed after 60s of inactivity... "
-if (timeout openssl s_client -quiet -connect "${TEST_HOST}":443); then 
-  echo PASS; 
-else 
-  retval=1; 
-  echo FAIL; 
+if (timeout openssl s_client -quiet -connect "${TEST_HOST}":443); then
+  echo PASS;
+else
+  retval=1;
+  echo FAIL;
 fi
 
 # We are explicitly disabling the followiung DNSSEC configuration validity test
 # until we can do it without relying on unknown intermediate resolver support
-# for DNSSEC. See issue here: 
+# for DNSSEC. See issue here:
 #   https://github.com/gsa/data.gov/issues/3751
 
 # echo -n "Waiting up to 600 seconds for the DNSSEC chain-of-trust to be validated... "
 # time=0
 # while true; do
 #   if [[ $(delv "${DOMAIN_NAME}" +yaml | grep -o '\s*\- fully_validated:' | wc -l) != 0 ]]; then
-#     echo PASS; 
-#     break; 
-#   elif [[ $time -gt 600 ]]; then 
-#     retval=1; 
-#     echo FAIL; 
-#     break; 
+#     echo PASS;
+#     break;
+#   elif [[ $time -gt 600 ]]; then
+#     retval=1;
+#     echo FAIL;
+#     break;
 #   fi
 #   time=$((time+5))
 #   sleep 5
@@ -211,7 +211,7 @@ sleep 10
 echo -n "Verify pod can write to EFS volume..."
 if (kubectl exec -ti ebs-app -- cat /data/out.txt | grep -q "Pod was here!"); then
     echo PASS
-else 
+else
     retval=1
     echo FAIL
 fi
@@ -239,7 +239,7 @@ pip3 install awscli --upgrade --user
 
 # Since we expect AWS creds are already set in the environment to a user for the broker to use, we
 # can use this command to generate the admin kubeconfig
-aws eks update-kubeconfig --kubeconfig "$KUBECONFIG" --name "$CLUSTER_NAME" 
+aws eks update-kubeconfig --kubeconfig "$KUBECONFIG" --name "$CLUSTER_NAME"
 
 # Test that the CIS EKS benchmark for the last node shows a total of zero FAIL results
 if (kubectl get CISKubeBenchReport "$(kubectl get nodes | tail -1 | cut -d ' ' -f 1)" -o json | jq -r '[.report.sections[].tests[].fail | tonumber] | add' | grep -q 0); then

--- a/test_specs/networkpolicy/allow_github.yml
+++ b/test_specs/networkpolicy/allow_github.yml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress-and-cloud-gov-ingress
+  namespace: default
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.31.0.0/16
+    - from:
+        - ipBlock:
+            cidr: 52.222.122.97/32
+    - from:
+        - ipBlock:
+            cidr: 52.222.123.172/32
+    - from:
+        - ipBlock:
+            cidr: <github-ip>


### PR DESCRIPTION
Relates to https://github.com/GSA/data.gov/issues/3355

This PR uses the pre-existing calico setup to deploy a networkpolicy to allow only connections from cloud.gov into the EKS worker pods.  It was coupled with the default-deny-egress policy to have a single default configuration that users are allowed to modify without the broker wanting to undo the user's changes.

This replaces #52, but there is still some good documentation about VPC configuration in that PR.

Cool Additional References:
- Github posts all of it's IP address ranges at https://api.github.com/meta
- Terraform [`kubernetes_network_policy`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy)
- k8s [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) documentation
- Cloud.gov [egress ranges](https://cloud.gov/docs/management/static-egress/#cloudgov-egress-ranges)