### PR TITLE
🧟 Revive the Dead

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,38 +11,38 @@ terraform_binaries:
   version: 1.1.5
   source: https://github.com/hashicorp/terraform/archive/v1.1.5.zip
 - name: terraform-provider-aws
-  version: 3.75.1
-  source: https://releases.hashicorp.com/terraform-provider-aws/3.75.1/terraform-provider-aws_3.75.1_linux_amd64.zip
+  version: 5.19.0
+  source: https://releases.hashicorp.com/terraform-provider-aws/5.19.0/terraform-provider-aws_5.19.0_linux_amd64.zip
 - name: terraform-provider-helm
-  version: 2.5.0
-  source: https://releases.hashicorp.com/terraform-provider-helm/2.5.0/terraform-provider-helm_2.5.0_linux_amd64.zip
+  version: 2.11.0
+  source: https://releases.hashicorp.com/terraform-provider-helm/2.11.0/terraform-provider-helm_2.11.0_linux_amd64.zip
 - name: terraform-provider-http
-  version: 2.1.0
-  source: https://releases.hashicorp.com/terraform-provider-http/2.1.0/terraform-provider-http_2.1.0_linux_amd64.zip
+  version: 3.4.0
+  source: https://releases.hashicorp.com/terraform-provider-http/3.4.0/terraform-provider-http_3.4.0_linux_amd64.zip
 - name: terraform-provider-kubernetes
-  version: 2.10.0
-  source: https://releases.hashicorp.com/terraform-provider-kubernetes/2.10.0/terraform-provider-kubernetes_2.10.0_linux_amd64.zip
+  version: 2.23.0
+  source: https://releases.hashicorp.com/terraform-provider-kubernetes/2.23.0/terraform-provider-kubernetes_2.23.0_linux_amd64.zip
 - name: terraform-provider-local
-  version: 2.2.2
-  source: https://releases.hashicorp.com/terraform-provider-local/2.2.2/terraform-provider-local_2.2.2_linux_amd64.zip
+  version: 2.4.0
+  source: https://releases.hashicorp.com/terraform-provider-local/2.4.0/terraform-provider-local_2.4.0_linux_amd64.zip
 - name: terraform-provider-null
-  version: 3.1.1
-  source: https://releases.hashicorp.com/terraform-provider-null/3.1.1/terraform-provider-null_3.1.1_linux_amd64.zip
+  version: 3.2.1
+  source: https://releases.hashicorp.com/terraform-provider-null/3.2.1/terraform-provider-null_3.2.1_linux_amd64.zip
 - name: terraform-provider-random
-  version: 3.1.2
-  source: https://releases.hashicorp.com/terraform-provider-random/3.1.2/terraform-provider-random_3.1.2_linux_amd64.zip
+  version: 3.5.1
+  source: https://releases.hashicorp.com/terraform-provider-random/3.5.1/terraform-provider-random_3.5.1_linux_amd64.zip
 - name: terraform-provider-template
   version: 2.2.0
   source: https://releases.hashicorp.com/terraform-provider-template/2.2.0/terraform-provider-template_2.2.0_linux_amd64.zip
 - name: terraform-provider-time
-  version: 0.7.2
-  source: https://releases.hashicorp.com/terraform-provider-time/0.7.2/terraform-provider-time_0.7.2_linux_amd64.zip
+  version: 0.9.1
+  source: https://releases.hashicorp.com/terraform-provider-time/0.9.1/terraform-provider-time_0.9.1_linux_amd64.zip
 - name: terraform-provider-tls
-  version: 3.3.0
-  source: https://releases.hashicorp.com/terraform-provider-tls/3.3.0/terraform-provider-tls_3.3.0_linux_amd64.zip
+  version: 4.0.4
+  source: https://releases.hashicorp.com/terraform-provider-tls/4.0.4/terraform-provider-tls_4.0.4_linux_amd64.zip
 - name: terraform-provider-cloudinit
-  version: 2.2.0
-  source: https://releases.hashicorp.com/terraform-provider-cloudinit/2.2.0/terraform-provider-cloudinit_2.2.0_linux_amd64.zip
+  version: 2.3.2
+  source: https://releases.hashicorp.com/terraform-provider-cloudinit/2.3.2/terraform-provider-cloudinit_2.3.2_linux_amd64.zip
 
 service_definitions:
 - eks-service-definition.yml

--- a/terraform/modules/provision-aws/Dockerfile
+++ b/terraform/modules/provision-aws/Dockerfile
@@ -1,6 +1,6 @@
 FROM hashicorp/terraform:1.1.5 as terraform
 
-FROM alpine/k8s:1.20.7
+FROM alpine/k8s:1.23.17
 
 COPY --from=terraform /bin/terraform /bin/terraform 
 

--- a/terraform/modules/provision-aws/Dockerfile
+++ b/terraform/modules/provision-aws/Dockerfile
@@ -1,6 +1,6 @@
 FROM hashicorp/terraform:1.1.5 as terraform
 
-FROM alpine/k8s:1.23.17
+FROM alpine/k8s:1.28.2
 
 COPY --from=terraform /bin/terraform /bin/terraform 
 

--- a/terraform/modules/provision-aws/crds.tf
+++ b/terraform/modules/provision-aws/crds.tf
@@ -1,3 +1,9 @@
+# TODO: This is working.. but if we don't need this, we shouldn't need to install
+# it.  It would be super cool if we found a way to move this configuration elsewhere.
+# The easiest solution is conditionally creating these resources on variable input.
+# However, it is just bloating the codebase.  I feel like this should be handled
+# separately.
+
 # -----------------------------------------------------------------------------
 # Install Solr operator and Zookeper operators so that their included CRDs will
 # be available to cluster users.

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -346,9 +346,9 @@ resource "null_resource" "cluster-functional" {
 # Kubernetes make use of these data sources so they won't be instantiated before
 # the cluster is ready for business.
 data "aws_eks_cluster" "main" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 data "aws_eks_cluster_auth" "main" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_name    = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
-  cluster_version = "1.23"
+  cluster_version = "1.28"
   kubeconfig_name = "kubeconfig-${local.cluster_name}"
 }
 

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -20,7 +20,7 @@ data "http" "myip" {
 
 module "eks" {
   source                                 = "terraform-aws-modules/eks/aws"
-  version                                = "~> 18.20.1"
+  version                                = "~> 19.16.0"
   cluster_name                           = local.cluster_name
   cluster_version                        = local.cluster_version
   vpc_id                                 = module.vpc.vpc_id

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -352,7 +352,3 @@ data "aws_eks_cluster" "main" {
 data "aws_eks_cluster_auth" "main" {
   name = module.eks.cluster_id
 }
-
-# data "aws_launch_template" "eks_launch_template" {
-#   id = module.eks.eks_managed_node_groups["system"].launch_template_id
-# }

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -29,6 +29,7 @@ module "eks" {
   cloudwatch_log_group_retention_in_days = 180
   enable_irsa                            = true
   cluster_endpoint_private_access        = true
+  cluster_endpoint_public_access         = true
   cluster_endpoint_public_access_cidrs = concat(
     var.control_plane_ingress_cidrs,        # User-specified IP
     ["${module.vpc.nat_public_ips[0]}/32"], # EKS Cluster Public IP

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -4,16 +4,6 @@ locals {
   kubeconfig_name = "kubeconfig-${local.cluster_name}"
 }
 
-data "aws_ami" "gsa-ise" {
-  count       = var.use_hardened_ami ? 1 : 0
-  owners      = ["self", "752281881774", "821341638715"]
-  most_recent = true
-  filter {
-    name   = "name"
-    values = ["ISE-AMZ-LINUX-EKS-v1.21-GSA-HARDENED*"]
-  }
-}
-
 data "http" "myip" {
   url = "http://ipv4.icanhazip.com"
 }

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -167,7 +167,7 @@ module "eks" {
 # Reference: https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest#%E2%84%B9%EF%B8%8F-error-invalid-for_each-argument-
 resource "aws_iam_role_policy_attachment" "pod-logging" {
   for_each = merge(
-    module.eks.eks_managed_node_groups,
+    # module.eks.eks_managed_node_groups,
     module.eks.fargate_profiles,
   )
 
@@ -177,7 +177,7 @@ resource "aws_iam_role_policy_attachment" "pod-logging" {
 
 resource "aws_iam_role_policy_attachment" "ebs-usage" {
   for_each = merge(
-    module.eks.eks_managed_node_groups,
+    # module.eks.eks_managed_node_groups,
     module.eks.fargate_profiles,
   )
 
@@ -187,7 +187,7 @@ resource "aws_iam_role_policy_attachment" "ebs-usage" {
 
 resource "aws_iam_role_policy_attachment" "ssm-usage" {
   for_each = merge(
-    module.eks.eks_managed_node_groups,
+    # module.eks.eks_managed_node_groups,
     module.eks.fargate_profiles,
   )
 
@@ -353,6 +353,6 @@ data "aws_eks_cluster_auth" "main" {
   name = module.eks.cluster_id
 }
 
-data "aws_launch_template" "eks_launch_template" {
-  id = module.eks.eks_managed_node_groups["system"].launch_template_id
-}
+# data "aws_launch_template" "eks_launch_template" {
+#   id = module.eks.eks_managed_node_groups["system"].launch_template_id
+# }

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -297,24 +297,27 @@ data "template_file" "kubeconfig" {
     kind: Config
     current-context: terraform
     clusters:
-    - name: ${data.aws_eks_cluster.main.name}
+    - name: ${data.aws_eks_cluster.main.arn}
       cluster:
         certificate-authority-data: ${data.aws_eks_cluster.main.certificate_authority.0.data}
         server: ${data.aws_eks_cluster.main.endpoint}
     contexts:
     - name: terraform
       context:
-        cluster: ${data.aws_eks_cluster.main.name}
+        cluster: ${data.aws_eks_cluster.main.arn}
         user: terraform
     users:
     - name: terraform
       user:
         exec:
           apiVersion: client.authentication.k8s.io/v1beta1
-          command: aws-iam-authenticator
+          command: aws
           args:
-            - "token"
-            - "-i"
+            - "--region"
+            - "${data.aws_region.current.name}"
+            - "eks"
+            - "get-token"
+            - "--cluster-name"
             - "${data.aws_eks_cluster.main.name}"
   EOF
 }

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -10,7 +10,7 @@ data "http" "myip" {
 
 module "eks" {
   source                                 = "terraform-aws-modules/eks/aws"
-  version                                = "~> 19.16.0"
+  version                                = "~> 19.17.2"
   cluster_name                           = local.cluster_name
   cluster_version                        = local.cluster_version
   vpc_id                                 = module.vpc.vpc_id
@@ -359,6 +359,7 @@ resource "null_resource" "cluster-functional" {
 # the cluster is ready for business.
 data "aws_eks_cluster" "main" {
   name = module.eks.cluster_name
+  depends_on = [module.eks.cluster_name]
 }
 
 data "aws_eks_cluster_auth" "main" {

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -309,7 +309,7 @@ data "template_file" "kubeconfig" {
     - name: terraform
       user:
         exec:
-          apiVersion: client.authentication.k8s.io/v1alpha1
+          apiVersion: client.authentication.k8s.io/v1beta1
           command: aws-iam-authenticator
           args:
             - "token"

--- a/terraform/modules/provision-aws/eks.tf
+++ b/terraform/modules/provision-aws/eks.tf
@@ -27,7 +27,11 @@ module "eks" {
   )
   tags = merge(var.labels,
     { "domain" = local.domain },
-    { "karpenter.sh/discovery" = local.cluster_name }
+    { "karpenter.sh/discovery" = local.cluster_name },
+    { "k8s.io/cluster-autoscaler/enabled" = true },
+    { "k8s.io/cluster-autoscaler/${local.cluster_name}" = local.cluster_name },
+    { "autoDiscovery.clusterName" = local.cluster_name },
+    { "awsRegion" = data.aws_region.current.name },
   )
   cluster_addons = {
     coredns = {

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -86,7 +86,7 @@ resource "helm_release" "ingress_nginx" {
       "controller.extraArgs.publish-status-address"  = local.domain,
       "serviceAccount.create"                        = true,
       "rbac.create"                                  = true,
-      "clusterName"                                  = module.eks.cluster_id,
+      "clusterName"                                  = module.eks.cluster_name,
       "region"                                       = local.region,
       "vpcId"                                        = module.vpc.vpc_id,
     }

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -20,7 +20,7 @@ module "aws_load_balancer_controller" {
   k8s_namespace    = "kube-system"
   aws_load_balancer_controller_chart_version = "1.6.1"
   aws_region_name  = data.aws_region.current.name
-  k8s_cluster_name = data.aws_eks_cluster.main.name
+  k8s_cluster_name = module.eks.cluster_name
   alb_controller_depends_on = [
     module.vpc,
     null_resource.cluster-functional,

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -15,9 +15,10 @@ locals {
 
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
-  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v5.0.1"
+  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=update-alb-controller-2.6.1"
   k8s_cluster_type = "eks"
   k8s_namespace    = "kube-system"
+  aws_load_balancer_controller_chart_version = "1.6.1"
   aws_region_name  = data.aws_region.current.name
   k8s_cluster_name = data.aws_eks_cluster.main.name
   alb_controller_depends_on = [

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -38,7 +38,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
-  version    = "4.0.17"
+  version    = "4.8.1"
 
   namespace       = "kube-system"
   cleanup_on_fail = "true"

--- a/terraform/modules/provision-aws/ingress.tf
+++ b/terraform/modules/provision-aws/ingress.tf
@@ -15,12 +15,12 @@ locals {
 
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
-  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=update-alb-controller-2.6.1"
-  k8s_cluster_type = "eks"
-  k8s_namespace    = "kube-system"
+  source                                     = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=update-alb-controller-2.6.1"
+  k8s_cluster_type                           = "eks"
+  k8s_namespace                              = "kube-system"
   aws_load_balancer_controller_chart_version = "1.6.1"
-  aws_region_name  = data.aws_region.current.name
-  k8s_cluster_name = module.eks.cluster_name
+  aws_region_name                            = data.aws_region.current.name
+  k8s_cluster_name                           = module.eks.cluster_name
   alb_controller_depends_on = [
     module.vpc,
     null_resource.cluster-functional,

--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -1,9 +1,9 @@
 locals {
   certificate_authority_data = module.eks.cluster_certificate_authority_data
   # persistent_storage_key_id  = aws_kms_key.ebs-key.key_id
-  server                     = module.eks.cluster_endpoint
-  zone_id                    = aws_route53_zone.cluster.zone_id
-  zone_role_arn              = aws_iam_role.external_dns.arn
+  server        = module.eks.cluster_endpoint
+  zone_id       = aws_route53_zone.cluster.zone_id
+  zone_role_arn = aws_iam_role.external_dns.arn
   # launch_template_name       = data.aws_launch_template.eks_launch_template.name
   vpc_cidr_range = module.vpc.vpc_cidr_block
 }

--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -4,6 +4,6 @@ locals {
   server                     = data.aws_eks_cluster.main.endpoint
   zone_id                    = aws_route53_zone.cluster.zone_id
   zone_role_arn              = aws_iam_role.external_dns.arn
-  launch_template_name       = data.aws_launch_template.eks_launch_template.name
+  # launch_template_name       = data.aws_launch_template.eks_launch_template.name
   vpc_cidr_range             = module.vpc.vpc_cidr_block
 }

--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -5,5 +5,5 @@ locals {
   zone_id                    = aws_route53_zone.cluster.zone_id
   zone_role_arn              = aws_iam_role.external_dns.arn
   # launch_template_name       = data.aws_launch_template.eks_launch_template.name
-  vpc_cidr_range             = module.vpc.vpc_cidr_block
+  vpc_cidr_range = module.vpc.vpc_cidr_block
 }

--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -1,6 +1,6 @@
 locals {
   certificate_authority_data = data.aws_eks_cluster.main.certificate_authority[0].data
-  persistent_storage_key_id  = aws_kms_key.ebs-key.key_id
+  # persistent_storage_key_id  = aws_kms_key.ebs-key.key_id
   server                     = data.aws_eks_cluster.main.endpoint
   zone_id                    = aws_route53_zone.cluster.zone_id
   zone_role_arn              = aws_iam_role.external_dns.arn

--- a/terraform/modules/provision-aws/locals/k8s-locals.tf
+++ b/terraform/modules/provision-aws/locals/k8s-locals.tf
@@ -1,7 +1,7 @@
 locals {
-  certificate_authority_data = data.aws_eks_cluster.main.certificate_authority[0].data
+  certificate_authority_data = module.eks.cluster_certificate_authority_data
   # persistent_storage_key_id  = aws_kms_key.ebs-key.key_id
-  server                     = data.aws_eks_cluster.main.endpoint
+  server                     = module.eks.cluster_endpoint
   zone_id                    = aws_route53_zone.cluster.zone_id
   zone_role_arn              = aws_iam_role.external_dns.arn
   # launch_template_name       = data.aws_launch_template.eks_launch_template.name

--- a/terraform/modules/provision-aws/maintenance.tf
+++ b/terraform/modules/provision-aws/maintenance.tf
@@ -1,4 +1,8 @@
 
+# TODO: again, SSM is only for managed node groups.  This configuration
+# doesn't conflict with anything.  But it is not necessary if we don't
+# use managed node groups
+
 resource "aws_ssm_maintenance_window" "window" {
   name     = "${local.cluster_name}-maintenance-window"
   schedule = "cron(0 16 ? * * *)"

--- a/terraform/modules/provision-aws/managed-node-groups.tf
+++ b/terraform/modules/provision-aws/managed-node-groups.tf
@@ -8,78 +8,78 @@
 #   policy_arn = data.aws_iam_policy.ssm_managed_instance.arn
 # }
 # 
-# resource "aws_iam_instance_profile" "karpenter" {
-#   name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
-#   role = module.eks.cluster_iam_role_name
-# }
+resource "aws_iam_instance_profile" "karpenter" {
+  name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
+  role = module.eks.cluster_iam_role_name
+}
 # 
-# module "iam_assumable_role_karpenter" {
-#   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-#   version                       = "4.7.0"
-#   create_role                   = true
-#   role_name                     = "karpenter-controller-${local.cluster_name}"
-#   provider_url                  = module.eks.cluster_oidc_issuer_url
-#   oidc_fully_qualified_subjects = ["system:serviceaccount:karpenter:karpenter"]
-# }
-# 
-# resource "aws_iam_role_policy" "karpenter_controller" {
-#   name = "karpenter-policy-${local.cluster_name}"
-#   role = module.iam_assumable_role_karpenter.iam_role_name
-# 
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Statement = [
-#       {
-#         Action = [
-#           "ec2:CreateLaunchTemplate",
-#           "ec2:CreateFleet",
-#           "ec2:RunInstances",
-#           "ec2:CreateTags",
-#           "iam:PassRole",
-#           "ec2:TerminateInstances",
-#           "ec2:DescribeLaunchTemplates",
-#           "ec2:DeleteLaunchTemplate",
-#           "ec2:DescribeInstances",
-#           "ec2:DescribeSecurityGroups",
-#           "ec2:DescribeSubnets",
-#           "ec2:DescribeInstanceTypes",
-#           "ec2:DescribeInstanceTypeOfferings",
-#           "ec2:DescribeAvailabilityZones",
-#           "ssm:GetParameter"
-#         ]
-#         Effect   = "Allow"
-#         Resource = "*"
-#       },
-#     ]
-#   })
-# }
-# 
-# resource "helm_release" "karpenter" {
-#   namespace        = "karpenter"
-#   create_namespace = true
-# 
-#   name       = "karpenter"
-#   repository = "https://charts.karpenter.sh"
-#   chart      = "karpenter"
-#   version    = "v0.8.0"
-# 
-#   dynamic "set" {
-#     for_each = {
-#       "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_karpenter.iam_role_arn,
-#       "clusterName"                                               = local.cluster_name,
-#       "clusterEndpoint"                                           = module.eks.cluster_endpoint,
-#       "aws.defaultInstanceProfile"                                = aws_iam_instance_profile.karpenter.name
-#     }
-#     content {
-#       name  = set.key
-#       value = set.value
-#     }
-#   }
-# 
-#   depends_on = [
-#     null_resource.cluster-functional
-#   ]
-# }
+module "iam_assumable_role_karpenter" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "5.30.0"
+  create_role                   = true
+  role_name                     = "karpenter-controller-${local.cluster_name}"
+  provider_url                  = module.eks.cluster_oidc_issuer_url
+  oidc_fully_qualified_subjects = ["system:serviceaccount:karpenter:karpenter"]
+}
+
+resource "aws_iam_role_policy" "karpenter_controller" {
+  name = "karpenter-policy-${local.cluster_name}"
+  role = module.iam_assumable_role_karpenter.iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateFleet",
+          "ec2:RunInstances",
+          "ec2:CreateTags",
+          "iam:PassRole",
+          "ec2:TerminateInstances",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeAvailabilityZones",
+          "ssm:GetParameter"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "helm_release" "karpenter" {
+  namespace        = "karpenter"
+  create_namespace = true
+
+  name       = "karpenter"
+  repository = "https://charts.karpenter.sh"
+  chart      = "karpenter"
+  version    = "v0.9.1"
+
+  dynamic "set" {
+    for_each = {
+      "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_karpenter.iam_role_arn,
+      "clusterName"                                               = local.cluster_name,
+      "clusterEndpoint"                                           = module.eks.cluster_endpoint,
+      "aws.defaultInstanceProfile"                                = aws_iam_instance_profile.karpenter.name
+    }
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
+  depends_on = [
+    null_resource.cluster-functional
+  ]
+}
 
 # data "aws_launch_template" "eks_launch_template" {
 #   id = module.eks.eks_managed_node_groups["system"].launch_template_id

--- a/terraform/modules/provision-aws/managed-node-groups.tf
+++ b/terraform/modules/provision-aws/managed-node-groups.tf
@@ -1,82 +1,82 @@
 
-data "aws_iam_policy" "ssm_managed_instance" {
-  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "karpenter_ssm_policy" {
-  role       = module.eks.cluster_iam_role_name
-  policy_arn = data.aws_iam_policy.ssm_managed_instance.arn
-}
-
-resource "aws_iam_instance_profile" "karpenter" {
-  name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
-  role = module.eks.cluster_iam_role_name
-}
-
-module "iam_assumable_role_karpenter" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "4.7.0"
-  create_role                   = true
-  role_name                     = "karpenter-controller-${local.cluster_name}"
-  provider_url                  = module.eks.cluster_oidc_issuer_url
-  oidc_fully_qualified_subjects = ["system:serviceaccount:karpenter:karpenter"]
-}
-
-resource "aws_iam_role_policy" "karpenter_controller" {
-  name = "karpenter-policy-${local.cluster_name}"
-  role = module.iam_assumable_role_karpenter.iam_role_name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "ec2:CreateLaunchTemplate",
-          "ec2:CreateFleet",
-          "ec2:RunInstances",
-          "ec2:CreateTags",
-          "iam:PassRole",
-          "ec2:TerminateInstances",
-          "ec2:DescribeLaunchTemplates",
-          "ec2:DeleteLaunchTemplate",
-          "ec2:DescribeInstances",
-          "ec2:DescribeSecurityGroups",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeInstanceTypes",
-          "ec2:DescribeInstanceTypeOfferings",
-          "ec2:DescribeAvailabilityZones",
-          "ssm:GetParameter"
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-  })
-}
-
-resource "helm_release" "karpenter" {
-  namespace        = "karpenter"
-  create_namespace = true
-
-  name       = "karpenter"
-  repository = "https://charts.karpenter.sh"
-  chart      = "karpenter"
-  version    = "v0.8.0"
-
-  dynamic "set" {
-    for_each = {
-      "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_karpenter.iam_role_arn,
-      "clusterName"                                               = local.cluster_name,
-      "clusterEndpoint"                                           = module.eks.cluster_endpoint,
-      "aws.defaultInstanceProfile"                                = aws_iam_instance_profile.karpenter.name
-    }
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  depends_on = [
-    null_resource.cluster-functional
-  ]
-}
+# data "aws_iam_policy" "ssm_managed_instance" {
+#   arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+# }
+# 
+# resource "aws_iam_role_policy_attachment" "karpenter_ssm_policy" {
+#   role       = module.eks.cluster_iam_role_name
+#   policy_arn = data.aws_iam_policy.ssm_managed_instance.arn
+# }
+# 
+# resource "aws_iam_instance_profile" "karpenter" {
+#   name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
+#   role = module.eks.cluster_iam_role_name
+# }
+# 
+# module "iam_assumable_role_karpenter" {
+#   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+#   version                       = "4.7.0"
+#   create_role                   = true
+#   role_name                     = "karpenter-controller-${local.cluster_name}"
+#   provider_url                  = module.eks.cluster_oidc_issuer_url
+#   oidc_fully_qualified_subjects = ["system:serviceaccount:karpenter:karpenter"]
+# }
+# 
+# resource "aws_iam_role_policy" "karpenter_controller" {
+#   name = "karpenter-policy-${local.cluster_name}"
+#   role = module.iam_assumable_role_karpenter.iam_role_name
+# 
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [
+#       {
+#         Action = [
+#           "ec2:CreateLaunchTemplate",
+#           "ec2:CreateFleet",
+#           "ec2:RunInstances",
+#           "ec2:CreateTags",
+#           "iam:PassRole",
+#           "ec2:TerminateInstances",
+#           "ec2:DescribeLaunchTemplates",
+#           "ec2:DeleteLaunchTemplate",
+#           "ec2:DescribeInstances",
+#           "ec2:DescribeSecurityGroups",
+#           "ec2:DescribeSubnets",
+#           "ec2:DescribeInstanceTypes",
+#           "ec2:DescribeInstanceTypeOfferings",
+#           "ec2:DescribeAvailabilityZones",
+#           "ssm:GetParameter"
+#         ]
+#         Effect   = "Allow"
+#         Resource = "*"
+#       },
+#     ]
+#   })
+# }
+# 
+# resource "helm_release" "karpenter" {
+#   namespace        = "karpenter"
+#   create_namespace = true
+# 
+#   name       = "karpenter"
+#   repository = "https://charts.karpenter.sh"
+#   chart      = "karpenter"
+#   version    = "v0.8.0"
+# 
+#   dynamic "set" {
+#     for_each = {
+#       "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_karpenter.iam_role_arn,
+#       "clusterName"                                               = local.cluster_name,
+#       "clusterEndpoint"                                           = module.eks.cluster_endpoint,
+#       "aws.defaultInstanceProfile"                                = aws_iam_instance_profile.karpenter.name
+#     }
+#     content {
+#       name  = set.key
+#       value = set.value
+#     }
+#   }
+# 
+#   depends_on = [
+#     null_resource.cluster-functional
+#   ]
+# }

--- a/terraform/modules/provision-aws/managed-node-groups.tf
+++ b/terraform/modules/provision-aws/managed-node-groups.tf
@@ -80,3 +80,7 @@
 #     null_resource.cluster-functional
 #   ]
 # }
+
+# data "aws_launch_template" "eks_launch_template" {
+#   id = module.eks.eks_managed_node_groups["system"].launch_template_id
+# }

--- a/terraform/modules/provision-aws/managed-node-groups.tf
+++ b/terraform/modules/provision-aws/managed-node-groups.tf
@@ -1,13 +1,4 @@
 
-# data "aws_iam_policy" "ssm_managed_instance" {
-#   arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-# }
-# 
-# resource "aws_iam_role_policy_attachment" "karpenter_ssm_policy" {
-#   role       = module.eks.cluster_iam_role_name
-#   policy_arn = data.aws_iam_policy.ssm_managed_instance.arn
-# }
-# 
 resource "aws_iam_instance_profile" "karpenter" {
   name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
   role = module.eks.cluster_iam_role_name
@@ -81,6 +72,10 @@ resource "helm_release" "karpenter" {
   ]
 }
 
+# TODO: Update with the newer AMI from GSA ISE in the managed node group case.
+# All account IDs were referenced here because this same code runs in development,
+# staging and prod.  So it needs to find the proper AMI, since it is account AND
+# region specific
 # data "aws_launch_template" "eks_launch_template" {
 #   id = module.eks.eks_managed_node_groups["system"].launch_template_id
 # }

--- a/terraform/modules/provision-aws/managed-node-groups.tf
+++ b/terraform/modules/provision-aws/managed-node-groups.tf
@@ -84,3 +84,12 @@
 # data "aws_launch_template" "eks_launch_template" {
 #   id = module.eks.eks_managed_node_groups["system"].launch_template_id
 # }
+# data "aws_ami" "gsa-ise" {
+#   count       = var.use_hardened_ami ? 1 : 0
+#   owners      = ["self", "752281881774", "821341638715"]
+#   most_recent = true
+#   filter {
+#     name   = "name"
+#     values = ["ISE-AMZ-LINUX-EKS-v1.21-GSA-HARDENED*"]
+#   }
+# }

--- a/terraform/modules/provision-aws/outputs.tf
+++ b/terraform/modules/provision-aws/outputs.tf
@@ -1,4 +1,4 @@
 output "domain_name" { value = local.domain }
-output "server" { value = data.aws_eks_cluster.main.endpoint }
-output "certificate_authority_data" { value = data.aws_eks_cluster.main.certificate_authority[0].data }
-output "cluster-id" { value = data.aws_eks_cluster.main.id }
+output "server" { value = module.eks.cluster_endpoint }
+output "certificate_authority_data" { value = module.eks.cluster_certificate_authority_data }
+output "cluster-id" { value = module.eks.cluster_id }

--- a/terraform/modules/provision-aws/outputs.tf
+++ b/terraform/modules/provision-aws/outputs.tf
@@ -1,4 +1,4 @@
 output "domain_name" { value = local.domain }
 output "server" { value = module.eks.cluster_endpoint }
 output "certificate_authority_data" { value = module.eks.cluster_certificate_authority_data }
-output "cluster-id" { value = module.eks.cluster_id }
+output "cluster-id" { value = module.eks.cluster_name }

--- a/terraform/modules/provision-aws/persistent-storage.tf
+++ b/terraform/modules/provision-aws/persistent-storage.tf
@@ -1,206 +1,156 @@
 locals {
-  ebs_key_policy = <<-POLICY
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "*"
-        },
-        "Action": "kms:*",
-        "Resource": "*"
-      }
-    ]
-  }
-  POLICY
-
-  ebs_policy = <<-EOF
+  efs_policy = <<-EOF
   {
     "Version": "2012-10-17",
     "Statement": [
       {
         "Effect": "Allow",
         "Action": [
-          "ec2:CreateSnapshot",
-          "ec2:AttachVolume",
-          "ec2:DetachVolume",
-          "ec2:ModifyVolume",
-          "ec2:DescribeAvailabilityZones",
-          "ec2:DescribeInstances",
-          "ec2:DescribeSnapshots",
-          "ec2:DescribeTags",
-          "ec2:DescribeVolumes",
-          "ec2:DescribeVolumesModifications"
+          "elasticfilesystem:DescribeAccessPoints",
+          "elasticfilesystem:DescribeFileSystems"
         ],
         "Resource": "*"
       },
       {
         "Effect": "Allow",
         "Action": [
-          "ec2:CreateTags"
+          "elasticfilesystem:CreateAccessPoint"
         ],
-        "Resource": [
-          "arn:aws:ec2:*:*:volume/*",
-          "arn:aws:ec2:*:*:snapshot/*"
-        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": "elasticfilesystem:DeleteAccessPoint",
+        "Resource": "*",
         "Condition": {
           "StringEquals": {
-            "ec2:CreateAction": [
-              "CreateVolume",
-              "CreateSnapshot"
-            ]
+            "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
           }
         }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteTags"
-        ],
-        "Resource": [
-          "arn:aws:ec2:*:*:volume/*",
-          "arn:aws:ec2:*:*:snapshot/*"
-        ]
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:CreateVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:CreateVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "aws:RequestTag/CSIVolumeName": "*"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:CreateVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "aws:RequestTag/kubernetes.io/cluster/*": "owned"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "ec2:ResourceTag/CSIVolumeName": "*"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteVolume"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteSnapshot"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ec2:DeleteSnapshot"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringLike": {
-            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "kms:CreateGrant",
-          "kms:ListGrants",
-          "kms:RevokeGrant"
-        ],
-        "Resource": ["<custom-key-id>"],
-        "Condition": {
-          "Bool": {
-            "kms:GrantIsForAWSResource": "true"
-          }
-        }
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-          "kms:GenerateDataKeyWithoutPlaintext"
-        ],
-        "Resource": ["<custom-key-id>"]
       }
     ]
   }
   EOF
 }
 
-# Default KMS Key Delegation is not enough since it restricts
-# the 'Principal' to only the root account.
-# This policy allows the EBS CSI to create additional keys
-# for each new EBS volume based on this root key.
-resource "aws_kms_key" "ebs-key" {
-  description             = "${local.cluster_name}-ebs-key"
-  deletion_window_in_days = 7
-  policy                  = local.ebs_key_policy
+resource "aws_security_group" "efs_mounts" {
+  name        = "efs_mounts"
+  description = "Mound EFS Volume in all pods w/i Fargate"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "NFS Traffic from Fargate"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  }
+
+  tags = {
+    Name = "allow_nfs_for_efs"
+  }
 }
 
-resource "aws_iam_policy" "ebs-usage" {
-  name_prefix = "${local.cluster_name}-ebs-policy"
-  policy      = replace(local.ebs_policy, "<custom-key-id>", aws_kms_key.ebs-key.arn)
+resource "aws_efs_file_system" "eks_efs" {
+  creation_token = "${local.cluster_name}-PV"
+
+  # encryption-at-rest
+  encrypted = true
+  tags = {
+    Name = "${local.cluster_name}-PV"
+  }
 }
+
+resource "aws_efs_file_system_policy" "policy" {
+  file_system_id = aws_efs_file_system.eks_efs.id
+
+  # encryption-in-transit
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Id": "${local.cluster_name}-efs-policy",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Action": [
+          "elasticfilesystem:ClientRootAccess",
+          "elasticfilesystem:ClientWrite",
+          "elasticfilesystem:ClientMount"
+        ],
+        "Condition": {
+          "Bool": {
+            "elasticfilesystem:AccessedViaMountTarget": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Deny",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Action": "*",
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      }
+    ]
+  }
+  POLICY
+}
+
+resource "aws_efs_mount_target" "efs_vpc" {
+  count           = 3
+  file_system_id  = aws_efs_file_system.eks_efs.id
+  subnet_id       = module.vpc.private_subnets[count.index]
+  security_groups = [aws_security_group.efs_mounts.id]
+}
+
+resource "aws_iam_role_policy" "efs-policy" {
+  name_prefix = "${local.cluster_name}-efs-policy"
+  role        = aws_iam_role.iam_role_fargate.name
+  policy      = local.efs_policy
+}
+
+# This isn't used for Fargate workloads, since they cannot dynamically provision
+# volumes:
+# https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html#:~:text=Considerations
+# However, we're leaving it here so that non-Fargate workloads can
+# still dynamically provision EFS volumes if they want to.
+resource "kubernetes_storage_class" "efs-sc" {
+  metadata {
+    name = "efs-sc"
+  }
+  storage_provisioner = "efs.csi.aws.com"
+  allow_volume_expansion = true
+}
+
+resource "kubernetes_persistent_volume" "pv" {
+  metadata {
+    name = "pv"
+  }
+  spec {
+    capacity = {
+      storage = "5Gi"
+    }
+    access_modes = ["ReadWriteOnce"]
+    storage_class_name = ""
+    persistent_volume_reclaim_policy = "Retain"
+    persistent_volume_source {
+      csi {
+        driver = "efs.csi.aws.com"
+        volume_handle = aws_efs_file_system.eks_efs.id
+      }
+    }
+  }
+}
+

--- a/terraform/modules/provision-aws/persistent-storage.tf
+++ b/terraform/modules/provision-aws/persistent-storage.tf
@@ -135,7 +135,7 @@ resource "kubernetes_storage_class" "efs-sc" {
   metadata {
     name = "efs-sc"
   }
-  storage_provisioner = "efs.csi.aws.com"
+  storage_provisioner    = "efs.csi.aws.com"
   allow_volume_expansion = true
 }
 
@@ -147,12 +147,12 @@ resource "kubernetes_persistent_volume" "pv" {
     capacity = {
       storage = "5Gi"
     }
-    access_modes = ["ReadWriteOnce"]
-    storage_class_name = ""
+    access_modes                     = ["ReadWriteOnce"]
+    storage_class_name               = ""
     persistent_volume_reclaim_policy = "Retain"
     persistent_volume_source {
       csi {
-        driver = "efs.csi.aws.com"
+        driver        = "efs.csi.aws.com"
         volume_handle = aws_efs_file_system.eks_efs.id
       }
     }

--- a/terraform/modules/provision-aws/persistent-storage.tf
+++ b/terraform/modules/provision-aws/persistent-storage.tf
@@ -1,3 +1,8 @@
+
+# TODO: This file blanket replaced EBS with EFS again.  If we want to
+# support both... OR if we need EBS for managed node groups.. this file
+# would need to change
+
 locals {
   efs_policy = <<-EOF
   {

--- a/terraform/modules/provision-aws/providers/provider-helm.tf
+++ b/terraform/modules/provision-aws/providers/provider-helm.tf
@@ -5,7 +5,7 @@ provider "helm" {
     token                  = data.aws_eks_cluster_auth.main.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["token", "--cluster-id", module.eks.cluster_id]
+      args        = ["token", "--cluster-id", module.eks.cluster_name]
       command     = "aws-iam-authenticator"
     }
   }

--- a/terraform/modules/provision-aws/providers/provider-helm.tf
+++ b/terraform/modules/provision-aws/providers/provider-helm.tf
@@ -1,7 +1,7 @@
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
-    cluster_ca_certificate = module.eks.cluster_certificate_authority_data
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.main.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"

--- a/terraform/modules/provision-aws/providers/provider-helm.tf
+++ b/terraform/modules/provision-aws/providers/provider-helm.tf
@@ -1,11 +1,11 @@
 provider "helm" {
   kubernetes {
-    host                   = data.aws_eks_cluster.main.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = module.eks.cluster_certificate_authority_data
     token                  = data.aws_eks_cluster_auth.main.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
+      args        = ["token", "--cluster-id", module.eks.cluster_id]
       command     = "aws-iam-authenticator"
     }
   }

--- a/terraform/modules/provision-aws/providers/provider-kubernetes.tf
+++ b/terraform/modules/provision-aws/providers/provider-kubernetes.tf
@@ -1,6 +1,6 @@
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = module.eks.cluster_certificate_authority_data
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.main.token
 
   exec {

--- a/terraform/modules/provision-aws/providers/provider-kubernetes.tf
+++ b/terraform/modules/provision-aws/providers/provider-kubernetes.tf
@@ -5,7 +5,7 @@ provider "kubernetes" {
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["token", "--cluster-id", module.eks.cluster_id]
+    args        = ["token", "--cluster-id", module.eks.cluster_name]
     command     = "aws-iam-authenticator"
   }
 }

--- a/terraform/modules/provision-aws/providers/provider-kubernetes.tf
+++ b/terraform/modules/provision-aws/providers/provider-kubernetes.tf
@@ -1,11 +1,11 @@
 provider "kubernetes" {
-  host                   = data.aws_eks_cluster.main.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = module.eks.cluster_certificate_authority_data
   token                  = data.aws_eks_cluster_auth.main.token
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
+    args        = ["token", "--cluster-id", module.eks.cluster_id]
     command     = "aws-iam-authenticator"
   }
 }

--- a/terraform/modules/provision-aws/standalone-outputs.tf
+++ b/terraform/modules/provision-aws/standalone-outputs.tf
@@ -5,4 +5,4 @@
 output "persistent_storage_key_id" { value = aws_kms_key.ebs-key.key_id }
 output "zone_id" { value = aws_route53_zone.cluster.zone_id }
 output "zone_role_arn" { value = aws_iam_role.external_dns.arn }
-output "launch_template_name" { value = data.aws_launch_template.eks_launch_template.name }
+# output "launch_template_name" { value = data.aws_launch_template.eks_launch_template.name }

--- a/terraform/modules/provision-aws/standalone-outputs.tf
+++ b/terraform/modules/provision-aws/standalone-outputs.tf
@@ -2,7 +2,7 @@
 # used as a standalone module. Leave it out if you're combining this directory
 # with the provision-k8s module.
 
-output "persistent_storage_key_id" { value = aws_kms_key.ebs-key.key_id }
+# output "persistent_storage_key_id" { value = aws_kms_key.ebs-key.key_id }
 output "zone_id" { value = aws_route53_zone.cluster.zone_id }
 output "zone_role_arn" { value = aws_iam_role.external_dns.arn }
 # output "launch_template_name" { value = data.aws_launch_template.eks_launch_template.name }

--- a/terraform/modules/provision-aws/versions.tf
+++ b/terraform/modules/provision-aws/versions.tf
@@ -2,26 +2,26 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 3.63"
+      version               = "~> 5.19"
       configuration_aliases = [aws.dnssec-key-provider]
     }
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~>2.4"
+      version = "~>2.11"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~>2.10"
+      version = "~>2.23"
     }
 
     local = {
       source  = "hashicorp/local"
-      version = "~>2.1"
+      version = "~>2.4"
     }
     http = {
       source  = "hashicorp/http"
-      version = "~>2.1"
+      version = "~>3.4"
     }
 
     null = {

--- a/terraform/modules/provision-aws/versions.tf
+++ b/terraform/modules/provision-aws/versions.tf
@@ -20,7 +20,7 @@ terraform {
       version = "~>2.1"
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
       version = "~>2.1"
     }
 

--- a/terraform/modules/provision-aws/vpc.tf
+++ b/terraform/modules/provision-aws/vpc.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.11.4"
+  version = "5.1.2"
   # insert the 23 required variables here
   name = "eks-vpc"
   cidr = "10.31.0.0/16"

--- a/terraform/modules/provision-k8s/k8s-admin-account.tf
+++ b/terraform/modules/provision-k8s/k8s-admin-account.tf
@@ -13,13 +13,13 @@ resource "kubernetes_service_account" "admin" {
 
 resource "kubernetes_secret" "admin" {
   metadata {
-    name = "admin-${random_id.name.hex}"
+    name      = "admin-${random_id.name.hex}"
     namespace = "kube-system"
     annotations = {
       "kubernetes.io/service-account.name" = "admin-${random_id.name.hex}"
     }
   }
-  type = "kubernetes.io/service-account-token"
+  type                           = "kubernetes.io/service-account-token"
   wait_for_service_account_token = true
 }
 

--- a/terraform/modules/provision-k8s/k8s-admin-account.tf
+++ b/terraform/modules/provision-k8s/k8s-admin-account.tf
@@ -11,6 +11,18 @@ resource "kubernetes_service_account" "admin" {
   }
 }
 
+resource "kubernetes_secret" "admin" {
+  metadata {
+    name = "admin-${random_id.name.hex}"
+    namespace = "kube-system"
+    annotations = {
+      "kubernetes.io/service-account.name" = "admin-${random_id.name.hex}"
+    }
+  }
+  type = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
+}
+
 # Bind the service account to the cluster-admin role
 resource "kubernetes_cluster_role_binding" "admin" {
   metadata {
@@ -30,14 +42,6 @@ resource "kubernetes_cluster_role_binding" "admin" {
   }
 }
 
-# Read in the generated secret for the service account
-data "kubernetes_secret" "secret" {
-  metadata {
-    name      = kubernetes_service_account.admin.default_secret_name
-    namespace = "kube-system"
-  }
-}
-
 # Generate a kubeconfig file with a token for the admin service account (which removes
 # the need for consumers to use aws-iam-authenticator or another binary).
 data "template_file" "admin_kubeconfig" {
@@ -47,7 +51,7 @@ data "template_file" "admin_kubeconfig" {
     users:
     - name: ${kubernetes_service_account.admin.metadata[0].name}
       user:
-        token: ${data.kubernetes_secret.secret.data.token}
+        token: ${kubernetes_secret.admin.data.token}
     clusters:
     - cluster:
         certificate-authority-data: ${local.certificate_authority_data}

--- a/terraform/modules/provision-k8s/k8s-autoscaler.tf
+++ b/terraform/modules/provision-k8s/k8s-autoscaler.tf
@@ -1,6 +1,11 @@
 # This is a workaround to use CRDs in the same Terraform pass as they are made
 # available. Explanation:
 # https://github.com/GSA/datagov-brokerpak-eks/pull/67#issuecomment-1093641392
+# TODO: Cross-reference the comment above and see if it's still valid in this
+# context... The relationship between karpenter and this autoscaler-provisioner
+# needs to be understood.  The autoscaler-provisioner mentions an auto-scaling
+# group (ASG) and I'm not sure if karpenter takes care of that.. or we need
+# to manage that separately
 resource "helm_release" "autoscaler-provisioner" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
@@ -12,6 +17,8 @@ resource "helm_release" "autoscaler-provisioner" {
       "autoDiscovery.clusterName" = local.cluster_name
       "awsRegion" = data.aws_region.current.name
 
+      # TODO: test out these tags, see if they are all needed in hopes of
+      # matching the karpenter configuration
       # { "karpenter.sh/discovery" = local.cluster_name },
       # { "k8s.io/cluster-autoscaler/enabled" = true },
       # { "k8s.io/cluster-autoscaler/${local.cluster_name}" = local.cluster_name },

--- a/terraform/modules/provision-k8s/k8s-autoscaler.tf
+++ b/terraform/modules/provision-k8s/k8s-autoscaler.tf
@@ -15,7 +15,7 @@ resource "helm_release" "autoscaler-provisioner" {
   dynamic "set" {
     for_each = {
       "autoDiscovery.clusterName" = local.cluster_name
-      "awsRegion" = data.aws_region.current.name
+      "awsRegion"                 = data.aws_region.current.name
 
       # TODO: test out these tags, see if they are all needed in hopes of
       # matching the karpenter configuration
@@ -24,7 +24,7 @@ resource "helm_release" "autoscaler-provisioner" {
       # { "k8s.io/cluster-autoscaler/${local.cluster_name}" = local.cluster_name },
       # { "autoDiscovery.clusterName" = local.cluster_name },
       # { "awsRegion" = data.aws_region.current.name },
-      }
+    }
     content {
       name  = set.key
       value = set.value

--- a/terraform/modules/provision-k8s/k8s-autoscaler.tf
+++ b/terraform/modules/provision-k8s/k8s-autoscaler.tf
@@ -2,30 +2,28 @@
 # available. Explanation:
 # https://github.com/GSA/datagov-brokerpak-eks/pull/67#issuecomment-1093641392
 resource "helm_release" "autoscaler-provisioner" {
-  name       = "autocaler-provisioner"
-  repository = "https://charts.itscontained.io"
-  chart      = "raw"
-  version    = "1.27.2"
-  values = [
-    <<-EOF
-    apiVersion: karpenter.sh/v1alpha5
-    kind: Provisioner
-    metadata:
-      name: default
-    spec:
-      requirements:
-        - key: eks.amazonaws.com/compute-type
-          operator: In
-          values: ["fargate"]
-      limits:
-        resources:
-          cpu: 1000
-      provider:
-        subnetSelector:
-          karpenter.sh/discovery: <cluster-name>
-      ttlSecondsAfterEmpty: 30
-    EOF
-  ]
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = "9.29.3"
+
+  dynamic "set" {
+    for_each = {
+      "autoDiscovery.clusterName" = local.cluster_name
+      "awsRegion" = data.aws_region.current.name
+
+      # { "karpenter.sh/discovery" = local.cluster_name },
+      # { "k8s.io/cluster-autoscaler/enabled" = true },
+      # { "k8s.io/cluster-autoscaler/${local.cluster_name}" = local.cluster_name },
+      # { "autoDiscovery.clusterName" = local.cluster_name },
+      # { "awsRegion" = data.aws_region.current.name },
+      }
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
   depends_on = [
     null_resource.cluster-functional,
     helm_release.karpenter

--- a/terraform/modules/provision-k8s/k8s-autoscaler.tf
+++ b/terraform/modules/provision-k8s/k8s-autoscaler.tf
@@ -5,7 +5,7 @@ resource "helm_release" "autoscaler-provisioner" {
   name       = "autocaler-provisioner"
   repository = "https://charts.itscontained.io"
   chart      = "raw"
-  version    = "0.2.5"
+  version    = "1.27.2"
   values = [
     <<-EOF
     apiVersion: karpenter.sh/v1alpha5
@@ -14,14 +14,13 @@ resource "helm_release" "autoscaler-provisioner" {
       name: default
     spec:
       requirements:
-        - key: karpenter.sh/capacity-type
+        - key: eks.amazonaws.com/compute-type
           operator: In
-          values: ["on-demand"]
+          values: ["fargate"]
       limits:
         resources:
           cpu: 1000
       provider:
-        launchTemplate: <launch-template-name>
         subnetSelector:
           karpenter.sh/discovery: <cluster-name>
       ttlSecondsAfterEmpty: 30

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -15,7 +15,7 @@ resource "helm_release" "calico" {
   atomic     = true
   repository = "https://docs.projectcalico.org/charts"
   chart      = "tigera-operator"
-  version    = "v3.22.1"
+  version    = "v3.26.2"
   depends_on = [
     null_resource.cluster-functional
   ]

--- a/terraform/modules/provision-k8s/k8s-network-policy.tf
+++ b/terraform/modules/provision-k8s/k8s-network-policy.tf
@@ -8,18 +8,22 @@ resource "kubernetes_namespace" "calico-system" {
   }
 }
 
-resource "helm_release" "calico" {
-  name       = "calico"
-  namespace  = kubernetes_namespace.calico-system.id
-  wait       = true
-  atomic     = true
-  repository = "https://docs.projectcalico.org/charts"
-  chart      = "tigera-operator"
-  version    = "v3.26.2"
-  depends_on = [
-    null_resource.cluster-functional
-  ]
-}
+# TODO: Get this working again.  The main story is that it is having issues
+# launching the pods because of descrepancies between the nodes and the pods.
+# You would see the issues when the helm chart is deploying by inspecting
+# the pod status
+# resource "helm_release" "calico" {
+#   name       = "calico"
+#   namespace  = kubernetes_namespace.calico-system.id
+#   wait       = true
+#   atomic     = true
+#   repository = "https://docs.projectcalico.org/charts"
+#   chart      = "tigera-operator"
+#   version    = "v3.26.2"
+#   depends_on = [
+#     null_resource.cluster-functional
+#   ]
+# }
 
 locals {
   # In future, we will extend this list

--- a/terraform/modules/provision-k8s/k8s-outputs.tf
+++ b/terraform/modules/provision-k8s/k8s-outputs.tf
@@ -1,5 +1,5 @@
 output "token" {
-  value       = data.kubernetes_secret.secret.data.token
+  value       = kubernetes_secret.admin.data.token
   description = "A cluster-admin token for use in constructing your own kubernetes configuration. NOTE: Do _not_ use this token when configuring the required_provider or you'll get a dependency cycle. Instead use exec with the same AWS credentials that were used for the required_providers aws provider."
   sensitive   = true
 }

--- a/terraform/modules/provision-k8s/k8s-persistent-storage.tf
+++ b/terraform/modules/provision-k8s/k8s-persistent-storage.tf
@@ -1,32 +1,32 @@
 
-resource "kubernetes_storage_class" "ebs-sc" {
-  metadata {
-    name = "ebs-sc"
-  }
-  parameters = {
-    encrypted = "true"
-    kmsKeyId  = local.persistent_storage_key_id
-  }
-  # Storage provisioner retrieved from
-  # https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
-  storage_provisioner    = "kubernetes.io/aws-ebs"
-  allow_volume_expansion = true
-
-  # Ensure volumes are created in the correct topology (specifically availability zone)
-  # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
-  volume_binding_mode = "WaitForFirstConsumer"
-
-  # The following code uses an optional nested block to define EBS volume parameters
-  # References:
-  # - https://codeinthehole.com/tips/conditional-nested-blocks-in-terraform/
-  # - https://medium.com/@business_99069/terraform-0-12-conditional-block-7d166e4abcbf
-  allowed_topologies {
-    dynamic "match_label_expressions" {
-      for_each = var.single_az ? [1] : []
-      content {
-        key    = "topology.ebs.csi.aws.com/zone"
-        values = ["${var.region}a"]
-      }
-    }
-  }
-}
+# resource "kubernetes_storage_class" "ebs-sc" {
+#   metadata {
+#     name = "ebs-sc"
+#   }
+#   parameters = {
+#     encrypted = "true"
+#     kmsKeyId  = local.persistent_storage_key_id
+#   }
+#   # Storage provisioner retrieved from
+#   # https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
+#   storage_provisioner    = "kubernetes.io/aws-ebs"
+#   allow_volume_expansion = true
+# 
+#   # Ensure volumes are created in the correct topology (specifically availability zone)
+#   # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
+#   volume_binding_mode = "WaitForFirstConsumer"
+# 
+#   # The following code uses an optional nested block to define EBS volume parameters
+#   # References:
+#   # - https://codeinthehole.com/tips/conditional-nested-blocks-in-terraform/
+#   # - https://medium.com/@business_99069/terraform-0-12-conditional-block-7d166e4abcbf
+#   allowed_topologies {
+#     dynamic "match_label_expressions" {
+#       for_each = var.single_az ? [1] : []
+#       content {
+#         key    = "topology.ebs.csi.aws.com/zone"
+#         values = ["${var.region}a"]
+#       }
+#     }
+#   }
+# }

--- a/terraform/modules/provision-k8s/k8s-scanning.tf
+++ b/terraform/modules/provision-k8s/k8s-scanning.tf
@@ -18,7 +18,7 @@ resource "helm_release" "starboard-operator" {
   atomic     = true
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "starboard-operator"
-  version    = "0.10.1"
+  version    = "0.10.12"
 
   values = [
     <<-EOF
@@ -34,6 +34,7 @@ resource "helm_release" "starboard-operator" {
       # Starboard docs all show this set to true; unclear if that's just an example of setting a value!
       # The default is false; see https://artifacthub.io/packages/helm/statcan/starboard-operator?modal=values
       # "trivy.ignoreUnfixed" = true
+      "replicas" = 1
     }
     content {
       name  = set.key

--- a/terraform/modules/provision-k8s/k8s-scanning.tf
+++ b/terraform/modules/provision-k8s/k8s-scanning.tf
@@ -11,34 +11,36 @@ resource "kubernetes_namespace" "starboard-system" {
   ]
 }
 
-resource "helm_release" "starboard-operator" {
-  name       = "starboard-operator"
-  namespace  = kubernetes_namespace.starboard-system.id
-  wait       = true
-  atomic     = true
-  repository = "https://aquasecurity.github.io/helm-charts/"
-  chart      = "starboard-operator"
-  version    = "0.10.12"
-
-  values = [
-    <<-EOF
-  EOF
-  ]
-
-  dynamic "set" {
-    for_each = {
-      # Once we're able to pull from the public ECR repository, we should uncomment these.
-      # "trivy.imageRef"      = "public.ecr.aws/aquasecurity/trivy:0.25.3"
-      # "image.repository"    = "public.ecr.aws/aquasecurity/starboard-operator"
-
-      # Starboard docs all show this set to true; unclear if that's just an example of setting a value!
-      # The default is false; see https://artifacthub.io/packages/helm/statcan/starboard-operator?modal=values
-      # "trivy.ignoreUnfixed" = true
-      "replicas" = 1
-    }
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-}
+# TODO: get this working again.  I haven't gotten to this issue as yet.
+# I feel like if we solve the calico issue, this might resolve as well.
+# resource "helm_release" "starboard-operator" {
+#   name       = "starboard-operator"
+#   namespace  = kubernetes_namespace.starboard-system.id
+#   wait       = true
+#   atomic     = true
+#   repository = "https://aquasecurity.github.io/helm-charts/"
+#   chart      = "starboard-operator"
+#   version    = "0.10.12"
+# 
+#   values = [
+#     <<-EOF
+#   EOF
+#   ]
+# 
+#   dynamic "set" {
+#     for_each = {
+#       # Once we're able to pull from the public ECR repository, we should uncomment these.
+#       # "trivy.imageRef"      = "public.ecr.aws/aquasecurity/trivy:0.25.3"
+#       # "image.repository"    = "public.ecr.aws/aquasecurity/starboard-operator"
+# 
+#       # Starboard docs all show this set to true; unclear if that's just an example of setting a value!
+#       # The default is false; see https://artifacthub.io/packages/helm/statcan/starboard-operator?modal=values
+#       # "trivy.ignoreUnfixed" = true
+#       "replicas" = 1
+#     }
+#     content {
+#       name  = set.key
+#       value = set.value
+#     }
+#   }
+# }


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4480
- https://github.com/GSA/data.gov/issues/4483
- https://github.com/GSA/data.gov/issues/3761
- https://github.com/GSA/data.gov/issues/3808
- https://github.com/GSA/terraform-kubernetes-aws-load-balancer-controller/pull/32

Checklist:
- [ ] Fix double `terraform apply` requirement
  - https://github.com/GSA/data.gov/issues/3617 provides some background on a "clean terraform apply"
- [ ] Review this PR as a team and make sure everyone is aware of all changes
- [ ] Reach out to @nickumia if there are any open questions about design choices
- [ ] Are the changes breaking?
  - If yes, check with active members/maintainers/users in [`#cg-contributors`](https://gsa-tts.slack.com/archives/C04LR4FBM2N)
  - If no, great job! 🥳 
- [ ] Are new tests required (and added) for changed resources?
- [ ] If fargate is working, do we really want to delete managed node groups??  If we ever need to switch back again, we'll have to revive work in the same way that this PR did to revive fargate 😖 
  - Oooo I think the best way to "consolidate" this is to offer TWO PLANS!!  We never really had a use-case for that before this 😲 

Background:
In an attempt to leverage k8s for airflow development, the `datagov-brokerpak-eks` repo needs to be on a [supported version of k8s](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar).  At the time of writing, there are `130 resources` managed by this terraform code.  Most of it is documented in our [cleanup documentation](https://github.com/GSA-TTS/datagov-brokerpak-eks/blob/main/docs/instance-cleanup.md).  These 130 resources are managed through `57 terraform resources` and `4 terraform modules` (`eks`, `aws_load_balancer_controller`, `vpc` and `iam_assumable_role_karpenter`).  Within these resources, Helm charts are used to create many more intangible resources inside of k8s.  Referencing all of the documentation and understanding how to make updates to this is important and requires time and effort.

Many resources were only included because we knew it was dependency, either through direct documentation or trial and error.  I'm trying to cover everything before 10/12; however, I suspect that there will be additional work to do.  See notes below on the status of current efforts.

Notes:
- If there is an EKS cluster provisioned already AND you change tags on the `module.eks` resource, you MUST delete the current cluster and reprovision from scratch, since the tags interfere with talking to the kubernetes control plane.
- How to locate the ALB Controller Helm Release:
  ![image](https://github.com/GSA-TTS/datagov-brokerpak-eks/assets/85196563/52e190b4-5897-41d8-9fe0-c8f61f9f80cb)

Misc Notes:
- [Link to deprecation warning](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/918aa7cc40cbc072836410747834de64d84f514d/main.tf#L392) for `eks` module
  ![image](https://github.com/GSA-TTS/datagov-brokerpak-eks/assets/85196563/2699d4ef-25cc-4b5c-b9e3-856eeb29a710)

References:
- [Main EKS Module](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest)
- [EKS Module -fargate_profiles](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest/submodules/fargate-profile?tab=inputs)
- Important [historical comment on autoscalers](https://github.com/GSA-TTS/datagov-brokerpak-eks/pull/67#issuecomment-1093641392)
- `autoscaler-provisioner` to `cluster-provisioner` docs
  - [Helm](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler)
  - Helm [value configs](https://github.com/kubernetes/autoscaler/blob/master/charts/cluster-autoscaler/values.yaml)
  - [AWS-specific config](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup)
- 